### PR TITLE
chore: remove code coverage reporting from kokoro tests

### DIFF
--- a/.kokoro/continuous/node8/test.cfg
+++ b/.kokoro/continuous/node8/test.cfg
@@ -1,9 +1,1 @@
-# Bring in codecov.io master token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "dpebot_codecov_token"
-    }
-  }
-}
+

--- a/.kokoro/presubmit/node8/test.cfg
+++ b/.kokoro/presubmit/node8/test.cfg
@@ -1,9 +1,1 @@
-# Bring in codecov.io master token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "dpebot_codecov_token"
-    }
-  }
-}
+

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -22,24 +22,3 @@ cd $(dirname $0)/..
 
 npm install
 npm test
-./node_modules/nyc/bin/nyc.js report
-
-
-WINDOWS="false"
-
- case $1 in
-  --windows)
-    WINDOWS="true"
-    ;;
-  "")
-    ;;
-  *)
-    echo "Unknown parameter: $1"
-    exit 1
-    ;;
-  esac
-
-if [ "$WINDOWS" -ne "true" ]; then
-  bash $KOKORO_GFILE_DIR/codecov.sh  
-fi
-


### PR DESCRIPTION
I'll add kokoro tests back after getting the token for uploading to codecov.io (and kokoro access to the token) set up.

After this change, kokoro tests should pass, I'll add the webhook to this repo.