### PR TITLE
cleanup: remove some unnecessary deps.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4368,11 +4368,6 @@
         "semver": "^5.1.0"
       }
     },
-    "parse-duration": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.1.1.tgz",
-      "integrity": "sha1-ExFN3JiRwezSgANiRFVN5DZHoiY="
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -248,21 +248,6 @@
         "@types/node": "*"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.121",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.121.tgz",
-      "integrity": "sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ==",
-      "dev": true
-    },
-    "@types/lodash.pickby": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash.pickby/-/lodash.pickby-4.6.5.tgz",
-      "integrity": "sha512-EB9NbFr8waE7z1JlKpH7s3rgHwAMYbnRjTRy0YXbkfkx2E1A9Bq6denQbFwFglJpuaVP5vAGAZeVx4JZkc1pBA==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
@@ -2475,11 +2460,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
-    },
-    "lodash.pickby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "bindings": "^1.2.1",
     "delay": "^4.0.1",
     "findit2": "^2.2.3",
-    "lodash.pickby": "^4.6.0",
     "nan": "^2.12.1",
     "node-pre-gyp": "^0.12.0",
     "p-limit": "^2.0.0",
@@ -43,7 +42,6 @@
     "split": "^1.0.1"
   },
   "devDependencies": {
-    "@types/lodash.pickby": "^4.6.5",
     "@types/mocha": "^5.0.0",
     "@types/node": "^10.0.3",
     "@types/p-limit": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "nan": "^2.12.1",
     "node-pre-gyp": "^0.12.0",
     "p-limit": "^2.0.0",
-    "parse-duration": "^0.1.1",
     "pify": "^4.0.0",
     "protobufjs": "~6.8.6",
     "source-map": "^0.6.1",

--- a/ts/third_party/cloud-debug-nodejs/src/agent/io/scanner.ts
+++ b/ts/third_party/cloud-debug-nodejs/src/agent/io/scanner.ts
@@ -18,7 +18,6 @@ import * as crypto from 'crypto';
 import * as events from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
-import pickBy = require('lodash.pickby');
 
 // TODO: Make this more precise.
 const findit: (dir: string) => events.EventEmitter = require('findit2');
@@ -40,7 +39,6 @@ export interface ScanStats {
 export interface ScanResults {
   errors(): Map<string, Error>;
   all(): ScanStats;
-  selectStats(regex: RegExp): ScanStats;
   selectFiles(regex: RegExp, baseDir: string): string[];
   hash?: string;
 }
@@ -71,18 +69,6 @@ class ScanResultsImpl implements ScanResults {
    */
   all(): ScanStats {
     return this.stats;
-  }
-
-  /**
-   * Used to get the file scan results for only the files
-   * whose filenames match the specified regex.
-   *
-   * @param {regex} regex The regex that tests a filename
-   *  to determine if the scan results for that filename
-   *  should be included in the returned results.
-   */
-  selectStats(regex: RegExp): ScanStats|{} {
-    return pickBy(this.stats, (_, key) => regex.test(key));
   }
 
   /**


### PR DESCRIPTION
It turns out that the code calling `lodash.pickyBy` was unreachable. `parse-duration` was unused in this module.