### PR TITLE
chore: add system tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build
 out
 node_modules
+system-test/busybench/package-lock.json

--- a/.kokoro/continuous/system_test.cfg
+++ b/.kokoro/continuous/system_test.cfg
@@ -1,0 +1,3 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "pprof-nodejs/system-test/system_test.sh"

--- a/.kokoro/presubmit/system_test.cfg
+++ b/.kokoro/presubmit/system_test.cfg
@@ -1,0 +1,3 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "pprof-nodejs/system-test/system_test.sh"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@
 
 **WIP** [pprof][pprof-url] support for Node.js.
 
+# Running the system test
+The system test starts a simple benchmark, uses this module to collect a time
+and a heap profile, and then verifies that the profiles can be opened and that
+the profiles contain functions from within the benchmark. 
+
+To run the system test, [golang](https://golang.org/) must be installed.
+
+The following command can be used to run the system test with all supported
+versions of Node.JS:
+```console
+$ sh system-test/system_test.sh
+```
+
+To run the system test with the v8 canary build, use:
+```console
+$ RUN_ONLY_V8_CANARY_TEST=true sh system-test/system_test.sh
+```
+
 [circle-image]: https://circleci.com/gh/google/pprof-nodejs.svg?style=svg
 [circle-url]: https://circleci.com/gh/google/pprof-nodejs
 [coveralls-image]: https://coveralls.io/repos/google/pprof-nodejs/badge.svg?branch=master&service=github

--- a/package-lock.json
+++ b/package-lock.json
@@ -2802,9 +2802,8 @@
       "dev": true
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+      "version": "git+https://github.com/nodejs/nan.git#d113c0282072e7ff4f9dfc98b432fd894b798c2c",
+      "from": "git+https://github.com/nodejs/nan.git"
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
-      "integrity": "sha1-mqSMGYkleHep2XEpbltzv+cuRG4=",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.3.tgz",
+      "integrity": "sha512-aEADYwRRZjJyMnKN7llGIlircxTCofm3dtV5pmY6ob18MSIuipHpA2yZWkPlycwu5HJcx/pADS3zssd8eY7/6A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.3.4",
+        "@babel/types": "^7.3.3",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.11",
         "source-map": "^0.5.0",
@@ -83,9 +83,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
-      "integrity": "sha1-pDNX5Lv0uSpDf7nkZcGShIKH8nw=",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.3.tgz",
+      "integrity": "sha512-xsH1CJoln2r74hR+y7cg2B5JCPaTh+Hd+EbBRk9nWGSNspuo6krjhX0Om6RnRQuIvFq8wVXCLKH3kwKDYhanSg==",
       "dev": true
     },
     "@babel/template": {
@@ -100,20 +100,20 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
-      "integrity": "sha1-EzCqtyI0+N6gkbCMT4udBccRngY=",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.3.4",
+        "@babel/generator": "^7.2.2",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.3.4",
-        "@babel/types": "^7.3.4",
+        "@babel/parser": "^7.2.3",
+        "@babel/types": "^7.2.2",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "debug": {
@@ -134,9 +134,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
-      "integrity": "sha1-v0gurq/7Nnooq7+TV6lJYyNdkO0=",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.3.tgz",
+      "integrity": "sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -199,9 +199,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@sinonjs/commons": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.1.tgz",
-      "integrity": "sha1-ukrl+pCPfYuWsOyN8GZayi2GlaQ=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha1-ez7C2Wr0gdegMhJS57HJRyTsWng=",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -215,18 +215,26 @@
       "requires": {
         "@sinonjs/commons": "^1",
         "@sinonjs/samsam": "^3.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/samsam": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.2.0.tgz",
+          "integrity": "sha1-WMYrXx9C5G0DnQc9CuJ1PaZ2vww=",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.0.2",
+            "array-from": "^2.1.1",
+            "lodash": "^4.17.11"
+          }
+        }
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.2.0.tgz",
-      "integrity": "sha1-WMYrXx9C5G0DnQc9CuJ1PaZ2vww=",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.0.2",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.11"
-      }
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.3.tgz",
+      "integrity": "sha1-Ys8qm2JO3HlRNBNf43/Cro6ja+M=",
+      "dev": true
     },
     "@sinonjs/text-encoding": {
       "version": "0.7.1",
@@ -261,18 +269,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.29.tgz",
-      "integrity": "sha1-wsjS0nu1Vkn7r+jqFzFlhCHzis8="
+      "version": "10.12.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.27.tgz",
+      "integrity": "sha512-e9wgeY6gaY21on3ve0xAjgBVjGDWq/xUteK0ujsE53bUoxycMkqfnkUgMt6ffZtykZ5X12Mg3T7Pw4TRCObDKg=="
     },
     "@types/p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@types/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha1-lKYI6bJYpsYVahPRoU/XINunC5c=",
-      "dev": true,
-      "requires": {
-        "p-limit": "*"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/p-limit/-/p-limit-2.0.0.tgz",
+      "integrity": "sha512-vx0HhwWQcrIzFn+Bx5OS6hk3wQ9++QjRyZgybM0+20MKqq1uYYgVjDxXk8+fFDfeGArep5l1laHCxEwltfzwYQ==",
+      "dev": true
     },
     "@types/pify": {
       "version": "3.0.2",
@@ -299,9 +304,9 @@
       }
     },
     "@types/sinon": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.9.tgz",
-      "integrity": "sha1-mBWT6jlqT7G2nj2LoE3gpCD9SxY=",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.6.tgz",
+      "integrity": "sha512-ldQl2p7kyCXHhr//5sQCu9jWgSiDbYuCD5dUp53r/z8T8jmgKpANpy4vqjbdho9P2ldFaQC/gpW31hch+oQ0IQ==",
       "dev": true
     },
     "@types/tmp": {
@@ -605,9 +610,9 @@
       }
     },
     "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.4.0.tgz",
+      "integrity": "sha512-7znEVX22Djn+nYjxCWKDne0RRloa9XfYa84yk3s+HkE3LpDYZmhArYr9O9huBoHY3/oXispx5LorIX7Sl2CgSQ==",
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -1654,15 +1659,15 @@
       }
     },
     "gaxios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.8.1.tgz",
-      "integrity": "sha1-YTROxKb8nvbxwe5iaNI+w7ju8qs=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.7.0.tgz",
+      "integrity": "sha512-2SaZTtaEgnSMgRrBVnPA5O9Tc8xWfnL48fuxFL7zOHZwnam3HiNOkoosnRgnkNBZoEZrH1Aja3wMCrrDtOEqUw==",
       "dev": true,
       "requires": {
         "abort-controller": "^2.0.2",
         "extend": "^3.0.2",
         "https-proxy-agent": "^2.2.1",
-        "node-fetch": "^2.3.0"
+        "node-fetch": "^2.2.0"
       }
     },
     "get-caller-file": {
@@ -1888,9 +1893,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha1-3hfyKYZMEgqfVpRXVuTzLEBFJF0=",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -2363,9 +2368,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha1-7x0GfFqdnLZb1y8oW12BBcd/FPw=",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -2463,6 +2468,12 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "log-symbols": {
@@ -2697,9 +2708,9 @@
       }
     },
     "mocha": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.0.2.tgz",
-      "integrity": "sha1-zcGm/fZkcsB5tWBbrFnSmAdwLSw=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.0.1.tgz",
+      "integrity": "sha512-tQzCxWqxSD6Oyg5r7Ptbev0yAMD8p+Vfh4snPFuiUsWqYj0eVYTDT2DkEY307FTj0WRlIWN9rWMMAUzRmijgVQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -2728,9 +2739,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-          "integrity": "sha1-51IqvaXtlMwEieG4RmYQ6IQEz0U=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
           "dev": true
         },
         "debug": {
@@ -2791,9 +2802,8 @@
       "dev": true
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha1-exqhk+mqhgV+PHu9CsRI53CSVVI="
+      "version": "git+https://github.com/nodejs/nan.git#d113c0282072e7ff4f9dfc98b432fd894b798c2c",
+      "from": "git+https://github.com/nodejs/nan.git"
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4322,9 +4332,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+      "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -4806,18 +4816,20 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "7.2.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.7.tgz",
-      "integrity": "sha1-7pD4POh9mmusQs8yoxA9jIsb+2g=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.0.0.tgz",
+      "integrity": "sha1-mfLlGY2QoBzLzr1NwYGiSCfLkN0=",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.3.1",
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.2.0",
+        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/formatio": "^3.0.0",
+        "@sinonjs/samsam": "^2.1.2",
         "diff": "^3.5.0",
-        "lolex": "^3.1.0",
-        "nise": "^1.4.10",
-        "supports-color": "^5.5.0"
+        "lodash.get": "^4.4.2",
+        "lolex": "^3.0.0",
+        "nise": "^1.4.5",
+        "supports-color": "^5.5.0",
+        "type-detect": "^4.0.8"
       }
     },
     "snapdragon": {
@@ -5259,9 +5271,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.13.1.tgz",
-      "integrity": "sha1-+8BUHEJWR6M82RCM5P1M0Y15BO0=",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+      "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -5272,7 +5284,6 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.7.0",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
@@ -5606,9 +5617,9 @@
           "dev": true
         },
         "camelcase": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-          "integrity": "sha1-51IqvaXtlMwEieG4RmYQ6IQEz0U=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
           "dev": true
         },
         "find-up": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2802,8 +2802,9 @@
       "dev": true
     },
     "nan": {
-      "version": "git+https://github.com/nodejs/nan.git#d113c0282072e7ff4f9dfc98b432fd894b798c2c",
-      "from": "git+https://github.com/nodejs/nan.git"
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "proto:profile": "mkdir -p proto && pbjs -t static-module -w commonjs -o proto/profile.js third_party/proto/profile.proto && pbts -o proto/profile.d.ts proto/profile.js",
     "license-check": "jsgl --local .",
     "docs-test": "linkinator docs -r --skip www.googleapis.com",
-    "predocs-test": "npm run docs"
+    "predocs-test": "npm run docs",
+    "//": "npm run system-test will fail; run the command for the system test from the command line",
+    "system-test": "sh system-test/system_test.sh"
   },
   "author": {
     "name": "Google Inc."

--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
     "proto:profile": "mkdir -p proto && pbjs -t static-module -w commonjs -o proto/profile.js third_party/proto/profile.proto && pbts -o proto/profile.d.ts proto/profile.js",
     "license-check": "jsgl --local .",
     "docs-test": "linkinator docs -r --skip www.googleapis.com",
-    "predocs-test": "npm run docs",
-    "//": "npm run system-test will fail; run the command for the system test from the command line",
-    "system-test": "sh system-test/system_test.sh"
+    "predocs-test": "npm run docs"
   },
   "author": {
     "name": "Google Inc."

--- a/system-test/busybench/package.json
+++ b/system-test/busybench/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "busybench",
+  "version": "1.0.0",
+  "description": "",
+  "main": "build/src/busybench.js",
+  "types": "build/src/busybench.d.ts",
+  "files": [
+    "build/src"
+  ],
+  "license": "Apache-2.0",
+  "keywords": [],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "check": "gts check",
+    "clean": "gts clean",
+    "compile": "tsc -p .",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run check"
+  },
+  "devDependencies": {},
+  "dependencies": {}
+}

--- a/system-test/busybench/src/busybench.ts
+++ b/system-test/busybench/src/busybench.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {writeFile} from 'fs';
+import * as pify from 'pify';
+import {encode, heap, time} from 'pprof';
+
+const writeFilePromise = pify(writeFile);
+
+const startTime: number = Date.now();
+const testArr: number[][] = [];
+
+/**
+ * Fills several arrays, then calls itself with setTimeout.
+ * It continues to do this until durationSeconds after the startTime.
+ */
+function busyLoop(durationSeconds: number) {
+  for (let i = 0; i < testArr.length; i++) {
+    for (let j = 0; j < testArr[i].length; j++) {
+      testArr[i][j] = Math.sqrt(j * testArr[i][j]);
+    }
+  }
+  if (Date.now() - startTime < 1000 * durationSeconds) {
+    setTimeout(() => busyLoop(durationSeconds), 5);
+  }
+}
+
+function benchmark(durationSeconds: number) {
+  // Allocate 16 MiB in 64 KiB chunks.
+  for (let i = 0; i < 16 * 16; i++) {
+    testArr[i] = new Array<number>(64 * 1024);
+  }
+  busyLoop(durationSeconds);
+}
+
+async function collectAndSaveTimeProfile(durationSeconds: number):
+    Promise<void> {
+  const profile = await time.profile({durationMillis: 1000 * durationSeconds});
+  const buf = await encode(profile);
+  await writeFilePromise('time.pb.gz', buf);
+}
+
+async function collectAndSaveHeapProfile(): Promise<void> {
+  const profile = heap.profile();
+  const buf = await encode(profile);
+  await writeFilePromise('heap.pb.gz', buf);
+}
+
+const durationSeconds = Number(process.argv.length > 2 ? process.argv[2] : 30);
+
+heap.start(512 * 1024, 64);
+benchmark(durationSeconds);
+collectAndSaveTimeProfile(durationSeconds);
+collectAndSaveHeapProfile();

--- a/system-test/busybench/tsconfig.json
+++ b/system-test/busybench/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "lib": [ "es2015" ]
+  },
+  "include": [
+    "src/*.ts",
+    "src/**/*.ts",
+    "test/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/system-test/system_test.go
+++ b/system-test/system_test.go
@@ -1,0 +1,224 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/google/pprof/profile"
+)
+
+var (
+	runOnlyV8CanaryTest = flag.Bool("run_only_v8_canary_test", false, "if true test will be run only with the v8-canary build, otherwise, no tests will be run with v8 canary build")
+	pprofDir            = flag.String("pprof_nodejs_path", "", "path to directory containing pprof-nodejs module")
+
+	runID = strings.Replace(time.Now().Format("2006-01-02-15-04-05.000000-0700"), ".", "-", -1)
+)
+
+var tmpl = template.Must(template.New("benchTemplate").Parse(`
+#! /bin/bash
+(
+
+retry() {
+  for i in {1..3}; do
+    "${@}" && return 0
+  done
+  return 1
+}
+
+# Display commands being run.
+set -x
+
+# Note directory from which test is being run.
+BASE_DIR=$(pwd)
+
+# Install desired version of Node.JS.
+# nvm install writes to stderr and stdout on successful install, so both are
+# redirected.
+. ~/.nvm/nvm.sh &>/dev/null # load nvm.
+{{if .NVMMirror}}NVM_NODEJS_ORG_MIRROR={{.NVMMirror}}{{end}} retry nvm install {{.NodeVersion}} &>/dev/null
+
+NODEDIR=$(dirname $(dirname $(which node)))
+
+# Build and pack pprof module.
+cd {{.PprofDir}}
+
+# TODO: remove this workaround when a new version of nan (current version 
+#       2.12.1) is released.
+# For v8-canary tests, we need to use the version of NAN on github, which 
+# contains unreleased fixes that allow the native component to be compiled
+# with Node's V8 canary build.
+{{if .NVMMirror}} retry npm install https://github.com/nodejs/nan.git {{end}} >/dev/null
+
+retry npm install --nodedir="$NODEDIR" >/dev/null
+npm run compile
+npm pack >/dev/null
+VERSION=$(node -e "console.log(require('./package.json').version);")
+PROFILER="{{.PprofDir}}/pprof-$VERSION.tgz"
+
+# Create and set up directory for running benchmark.
+TESTDIR="$BASE_DIR/{{.Name}}"
+mkdir -p "$TESTDIR"
+cp -r "$BASE_DIR/busybench" "$TESTDIR"
+cd "$TESTDIR/busybench"
+
+retry npm install pify @types/pify typescript gts @types/node >/dev/null
+retry npm install --nodedir="$NODEDIR" --build-from-source=pprof "$PROFILER" >/dev/null
+npm run compile >/dev/null
+
+# Run benchmark, which will collect and save profiles.
+node -v
+node --trace-warnings build/src/busybench.js {{.DurationSec}}
+
+# Write all output standard out with timestamp.
+) 2>&1 | while read line; do echo "$(date): ${line}"; done >&1
+`))
+
+type profileSummary struct {
+	profileType  string
+	functionName string
+	sourceFile   string
+}
+
+type pprofTestCase struct {
+	name         string
+	nodeVersion  string
+	nvmMirror    string
+	wantProfiles []profileSummary
+}
+
+func (tc *pprofTestCase) generateScript(tmpl *template.Template) (string, error) {
+	var buf bytes.Buffer
+	err := tmpl.Execute(&buf,
+		struct {
+			Name        string
+			NodeVersion string
+			NVMMirror   string
+			DurationSec int
+			PprofDir    string
+		}{
+			Name:        tc.name,
+			NodeVersion: tc.nodeVersion,
+			NVMMirror:   tc.nvmMirror,
+			DurationSec: 10,
+			PprofDir:    *pprofDir,
+		})
+	if err != nil {
+		return "", fmt.Errorf("failed to render benchmark script for %s: %v", tc.name, err)
+	}
+	filename := fmt.Sprintf("%s.sh", tc.name)
+	if err := ioutil.WriteFile(filename, buf.Bytes(), os.ModePerm); err != nil {
+		return "", fmt.Errorf("failed to write benchmark script for %s to %s: %v", tc.name, filename, err)
+	}
+	return filename, nil
+}
+
+func TestAgentIntegration(t *testing.T) {
+	wantProfiles := []profileSummary{
+		{profileType: "time", functionName: "busyLoop", sourceFile: "busybench.js"},
+		{profileType: "heap", functionName: "benchmark", sourceFile: "busybench.js"},
+	}
+
+	testcases := []pprofTestCase{
+		{
+			name:         fmt.Sprintf("pprof-node6-%s", runID),
+			wantProfiles: wantProfiles,
+			nodeVersion:  "6",
+		},
+		{
+			name:         fmt.Sprintf("pprof-node8-%s", runID),
+			wantProfiles: wantProfiles,
+			nodeVersion:  "8",
+		},
+		{
+			name:         fmt.Sprintf("pprof-node10-%s", runID),
+			wantProfiles: wantProfiles,
+			nodeVersion:  "10",
+		},
+		{
+			name:         fmt.Sprintf("pprof-node11-%s", runID),
+			wantProfiles: wantProfiles,
+			nodeVersion:  "11",
+		},
+	}
+	if *runOnlyV8CanaryTest {
+		testcases = []pprofTestCase{{
+			name:         fmt.Sprintf("pprof-v8-canary-%s", runID),
+			wantProfiles: wantProfiles,
+			nodeVersion:  "node", // install latest version of node
+			nvmMirror:    "https://nodejs.org/download/v8-canary",
+		}}
+	}
+
+	// Prevent test cases from running in parallel.
+	runtime.GOMAXPROCS(1)
+
+	for _, tc := range testcases {
+		tc := tc // capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			bench, err := tc.generateScript(tmpl)
+			if err != nil {
+				t.Fatalf("failed to initialize bench script: %v", err)
+			}
+
+			cmd := exec.Command("/bin/bash", bench)
+			var testOut bytes.Buffer
+			cmd.Stdout = &testOut
+			err = cmd.Run()
+			t.Log(testOut.String())
+			if err != nil {
+				t.Fatalf("failed to execute benchmark: %v", err)
+			}
+
+			for _, wantProfile := range tc.wantProfiles {
+				profilePath := fmt.Sprintf("%s/busybench/%s.pb.gz", tc.name, wantProfile.profileType)
+				if err := checkProfile(profilePath, wantProfile); err != nil {
+					t.Errorf("failed to collect expected %s profile: %v", wantProfile.profileType, err)
+				}
+			}
+		})
+	}
+}
+
+func checkProfile(path string, want profileSummary) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open profile: %v", err)
+	}
+
+	pr, err := profile.Parse(f)
+	if err != nil {
+		return fmt.Errorf("failed to parse profile: %v", err)
+	}
+
+	for _, loc := range pr.Location {
+		for _, line := range loc.Line {
+			if want.functionName == line.Function.Name && strings.HasSuffix(line.Function.Filename, want.sourceFile) {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("Location (function: %s, file: %s) not found in profiles of type %s", want.functionName, want.sourceFile, want.profileType)
+}

--- a/system-test/system_test.sh
+++ b/system-test/system_test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+retry() {
+  for i in {1..3}; do
+    "${@}" && return 0
+  done
+  return 1
+}
+
+# Fail on any error.
+set -eo pipefail
+
+# Display commands being run.
+set -x
+
+# Record directory of pprof-nodejs.
+cd $(dirname $0)/..
+BASE_DIR=$(pwd)
+
+RUN_ONLY_V8_CANARY_TEST="${RUN_ONLY_V8_CANARY_TEST:-false}"
+echo "$RUN_ONLY_V8_CANARY_TEST"
+
+# Install nvm.
+retry curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash &>/dev/null
+export NVM_DIR="$HOME/.nvm" &>/dev/null
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" &>/dev/null
+
+# Move test to go path.
+export GOPATH="$HOME/go"
+mkdir -p "$GOPATH/src"
+
+cp -R "system-test" "$GOPATH/src/pproftest"
+
+# Run test.
+cd "$GOPATH/src/pproftest"
+retry go get -t -d .
+go test -v -timeout=10m -run TestAgentIntegration -pprof_nodejs_path="$BASE_DIR" -run_only_v8_canary_test="$RUN_ONLY_V8_CANARY_TEST"

--- a/system-test/system_test.sh
+++ b/system-test/system_test.sh
@@ -25,13 +25,14 @@ retry curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.
 export NVM_DIR="$HOME/.nvm" &>/dev/null
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" &>/dev/null
 
-# Move test to go path.
-export GOPATH="$HOME/go"
-mkdir -p "$GOPATH/src"
-
-cp -R "system-test" "$GOPATH/src/pproftest"
+# Move system test to separate directory to run.
+TESTDIR="$BASE_DIR/run-system-test"
+cp -R "system-test" "$TESTDIR"
 
 # Run test.
-cd "$GOPATH/src/pproftest"
+cd "$TESTDIR"
 retry go get -t -d .
 go test -v -timeout=10m -run TestAgentIntegration -pprof_nodejs_path="$BASE_DIR" -run_only_v8_canary_test="$RUN_ONLY_V8_CANARY_TEST"
+
+# Remove directory where test was run.
+rm -r $TESTDIR


### PR DESCRIPTION
Set up initial system tests for pprof-nodejs. 

Tested:
Looked at system test output logs to confirm expected version of Node is used. 
Locally ran validate that v8-canary test will run once kokoro configs are setup for it.

System tests which test the SourceMapper will be in a follow-up change.