### PR TITLE
v0.2.0-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pprof",
-  "version": "0.1.0",
+  "version": "0.2.0-alpha.0",
   "description": "pprof support for Node.js",
   "repository": "google/pprof-nodejs",
   "main": "out/src/index.js",

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -35,4 +35,4 @@ NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/73713_google_cloud_npm_token)
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
 retry npm install
-npm publish --access=public
+npm publish --access=public --tag alpha


### PR DESCRIPTION
Release notes: https://github.com/google/pprof-nodejs/releases/tag/untagged-342009bae76f787b1e1a

After this PR is in, I plan to trigger the release workflow. 

I don't expect that the workflow for publishing will be successful initially, but I feel that being able to try out the release workflow will be the quickest way to debug any issues.

I've updated the publishing script to tag the release as an alpha release (and the version is an alpha version), so if a version is released, it won't be downloaded unless this version is specifically requested.