### PR TITLE
fix: publish binaries to GCS bucket location referenced in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pprof",
-  "version": "0.2.0-alpha.0",
+  "version": "0.2.0-alpha.3",
   "description": "pprof support for Node.js",
   "repository": "google/pprof-nodejs",
   "main": "out/src/index.js",

--- a/tools/build/linux_build_and_test.sh
+++ b/tools/build/linux_build_and_test.sh
@@ -64,5 +64,5 @@ export BINARY_HOST="https://storage.googleapis.com/${GCS_LOCATION}"
 "${BASE_DIR}/system-test/system_test.sh"
 
 if [ "$BUILD_TYPE" == "release" ]; then
-  retry gsutil cp -r "${BASE_DIR}/artifacts/." "gs://cloud-profiler/nodejs/release"
+  retry gsutil cp -r "${BASE_DIR}/artifacts/." "gs://cloud-profiler/pprof-nodejs/release"
 fi


### PR DESCRIPTION
This allows node-pre-gyp to find the binaries.