### PR TITLE
v0.2.0; release agent with pre-compiled binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,4 @@
 ---
-release_tags: &release_tags
-  tags:
-    only: /^v\d+(\.\d+){2}(-.*)?$/
 
 # "Include" for unit tests definition.
 unit_tests: &unit_tests
@@ -49,30 +46,12 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node6:
-           filters: *release_tags
-      - node8:
-           filters: *release_tags
-      - node10:
-          filters: *release_tags
-      - node11:
-          filters: *release_tags
-      - gocheck:
-          filters: *release_tags
-      - npmaudit:
-          filters: *release_tags
-      - publish_npm:
-          requires:
-            - node6
-            - node8
-            - node10
-            - node11
-            - gocheck
-            - npmaudit
-          filters:
-            branches:
-              ignore: /.*/
-            <<: *release_tags
+      - node6
+      - node8
+      - node10
+      - node11
+      - gocheck
+      - npmaudit
 
 jobs:
   node6:
@@ -107,20 +86,3 @@ jobs:
     docker:
       - image: circleci/golang:1.12
     <<: *gochecks
-
-  publish_npm:
-    docker:
-      - image: node:8
-        user: node
-    steps:
-      - checkout
-      - run:
-          name: Set NPM authentication.
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-      - run:
-          name: Install modules and dependencies.
-          command: npm install
-      - run:
-          name: Publish the module to npm.
-          command: npm publish
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pprof",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0",
   "description": "pprof support for Node.js",
   "repository": "google/pprof-nodejs",
   "main": "out/src/index.js",

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -36,4 +36,4 @@ echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
 retry npm install
 npm publish --access=public \
-    --registry=https://wombat-dressing-room.appspot.com --tag alpha
+    --registry=https://wombat-dressing-room.appspot.com


### PR DESCRIPTION
Release notes: https://github.com/google/pprof-nodejs/releases/edit/untagged-3573aa9fd72d459d0c05

This change also remove the release process using circle CI. Right now, to release, one must manually trigger the kokoro release workflow after adding a commit to bump the version.

Precompile binaries were tested with cloud-profiler-nodejs here: https://github.com/googleapis/cloud-profiler-nodejs/pull/442 (logs [here](https://sponge.corp.google.com/target?id=855415d8-8510-4307-a92e-5faf77c970ac&target=cloud-profiler%2Fnodejs-agent%2Fpresubmit%2Fpresubmit&searchFor=)).

