### PR TITLE
chore: add system tests which do not use prebuilt binaries

### DIFF
--- a/tools/kokoro/system-test/continuous/linux-prebuild.cfg
+++ b/tools/kokoro/system-test/continuous/linux-prebuild.cfg
@@ -1,0 +1,12 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 72935
+      keyname: "cloud-profiler-e2e-service-account-key"
+    }
+  }
+}
+
+build_file: "pprof-nodejs/tools/build/linux_build_and_test.sh"

--- a/tools/kokoro/system-test/continuous/linux.cfg
+++ b/tools/kokoro/system-test/continuous/linux.cfg
@@ -1,12 +1,3 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 72935
-      keyname: "cloud-profiler-e2e-service-account-key"
-    }
-  }
-}
-
-build_file: "pprof-nodejs/tools/build/linux_build_and_test.sh"
+build_file: "pprof-nodejs/system-test/system_test.sh"

--- a/tools/kokoro/system-test/presubmit/linux-prebuild.cfg
+++ b/tools/kokoro/system-test/presubmit/linux-prebuild.cfg
@@ -1,0 +1,12 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 72935
+      keyname: "cloud-profiler-e2e-service-account-key"
+    }
+  }
+}
+
+build_file: "pprof-nodejs/tools/build/linux_build_and_test.sh"

--- a/tools/kokoro/system-test/presubmit/linux.cfg
+++ b/tools/kokoro/system-test/presubmit/linux.cfg
@@ -1,12 +1,3 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 72935
-      keyname: "cloud-profiler-e2e-service-account-key"
-    }
-  }
-}
-
-build_file: "pprof-nodejs/tools/build/linux_build_and_test.sh"
+build_file: "pprof-nodejs/system-test/system_test.sh"


### PR DESCRIPTION
This test adds kokoro configs for running system tests without pre-building binaries.

After this change (until follow-up changes are made to kokoro job configs, so tests associated with the "linux-prebuild.cfg"s are added), no system test will use pre-built binaries.