### PR TITLE
fix: Specify target in tsconfig to fix Node 6 system test

### DIFF
--- a/system-test/busybench/tsconfig.json
+++ b/system-test/busybench/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
-    "lib": [ "es2015" ]
+    "lib": [ "es2015" ],
+    "target": "es2015"
   },
   "include": [
     "src/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "ts",
     "outDir": "out",
-    "lib": [ "es2015" ]
+    "lib": [ "es2015" ],
+    "target": "es2015"
   },
   "include": [
     "ts/**/*.ts"


### PR DESCRIPTION
Specifying `target` in the main tsconfig.json was not necessary to make system tests pass, but seemed prudent given the problem we had with the benchmark.