### PR TITLE
chore: silence deprecation warnings that appear with gcc 8

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,11 @@
       "sources": [ 
         "bindings/profiler.cc",
       ],
-      "include_dirs": [ "<!(node -e \"require('nan')\")" ]
+      "include_dirs": [ "<!(node -e \"require('nan')\")" ],
+      # TODO(#62): The following line suppresses compliation warnings
+      # originating from v8 and node that appear when gcc 8 is used.
+      # Once the warnings are fixed upstream, this line should be removed.
+      "cflags": [ "-Wno-cast-function-type" ]
     },
     {
       "target_name": "action_after_build",


### PR DESCRIPTION
Confirmed that warnings including "cast between incompatible function types" did not appear in the linux prebuild presubmit test.