### PR TITLE
feat: allow collecting profiles with more accurate line numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 out
 node_modules
 system-test/busybench/package-lock.json
+system-test/busybench-js/package-lock.json

--- a/bindings/profiler.cc
+++ b/bindings/profiler.cc
@@ -105,7 +105,7 @@ CpuProfiler* cpuProfiler = CpuProfiler::New(v8::Isolate::GetCurrent());
 CpuProfiler* cpuProfiler = v8::Isolate::GetCurrent()->GetCpuProfiler();
 #endif
 
-Local<Object> CreateTimeNode(Local<String> name, Local<String> scriptName, 
+Local<Object> CreateTimeNode(Local<String> name, Local<String> scriptName,
                          Local<Integer> scriptId, Local<Integer> lineNumber,
                          Local<Integer> columnNumber, Local<Integer> hitCount,
                          Local<Array> children) {
@@ -136,7 +136,7 @@ Local<Array> GetLineNumberTimeProfileChildren(const CpuProfileNode* parent,
   if (hitLineCount > 0) {
     CpuProfileNode::LineTick entries[hitLineCount];
     node->GetLineTicks(&entries[0], hitLineCount);
-    children = Nan::New<Array>(count + entries.size());
+    children = Nan::New<Array>(count + hitLineCount);
     for (const CpuProfileNode::LineTick entry : entries) {
       children->Set(index++, CreateTimeNode(
         node->GetFunctionName(),
@@ -265,7 +265,7 @@ Local<Value> TranslateTimeProfile(const CpuProfile* profile, bool hasDetailedLin
 }
 
 // Signature:
-// startProfiling(runName: string, includeLineInfo?: boolean)
+// startProfiling(runName: string, includeLineInfo: boolean)
 NAN_METHOD(StartProfiling) {
   if (info.Length() != 2) {
     return Nan::ThrowTypeError("StartProfling must have two arguments.");
@@ -300,7 +300,7 @@ bool recordSamples = false;
 }
 
 // Signature:
-// stopProfiling(runName: string, includedLineInfo?: boolean): TimeProfile
+// stopProfiling(runName: string, includedLineInfo: boolean): TimeProfile
 NAN_METHOD(StopProfiling) {
   if (info.Length() != 2) {
     return Nan::ThrowTypeError("StopProfling must have two arguments.");

--- a/bindings/profiler.cc
+++ b/bindings/profiler.cc
@@ -101,37 +101,158 @@ CpuProfiler* cpuProfiler = CpuProfiler::New(v8::Isolate::GetCurrent());
 CpuProfiler* cpuProfiler = v8::Isolate::GetCurrent()->GetCpuProfiler();
 #endif
 
+Local<Object> CreateTimeNode(Local<String> name, Local<String> scriptName, 
+                         Local<Integer> scriptId, Local<Integer> lineNumber,
+                         Local<Integer> columnNumber, Local<Integer> hitCount,
+                         Local<Array> children) {
+  Local<Object> js_node = Nan::New<Object>();
+  js_node->Set(Nan::New<String>("name").ToLocalChecked(), name);
+  js_node->Set(Nan::New<String>("scriptName").ToLocalChecked(), scriptName);
+  js_node->Set(Nan::New<String>("scriptId").ToLocalChecked(), scriptId);
+  js_node->Set(Nan::New<String>("lineNumber").ToLocalChecked(), lineNumber);
+  js_node->Set(Nan::New<String>("columnNumber").ToLocalChecked(), columnNumber);
+  js_node->Set(Nan::New<String>("hitCount").ToLocalChecked(), hitCount);
+  js_node->Set(Nan::New<String>("children").ToLocalChecked(), children);
+  return js_node;
+}
+
+
+#if NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION
+Local<Object> TranslateLineNumbersTimeProfileNode(const CpuProfileNode* parent,
+                                      const CpuProfileNode* node);
+
+Local<Array> GetLineNumberTimeProfileChildren(const CpuProfileNode* parent,
+                                      const CpuProfileNode* node) {
+  unsigned int index = 0;
+  Local<Array> children;
+  int32_t count = node->GetChildrenCount();
+
+  unsigned int hitLineCount = node->GetHitLineCount();
+  unsigned int hitCount = node->GetHitCount();
+  if (hitLineCount > 0) {
+    std::vector<CpuProfileNode::LineTick> entries(hitLineCount);
+    node->GetLineTicks(&entries[0], hitLineCount);
+    children = Nan::New<Array>(count + entries.size());
+    for (const CpuProfileNode::LineTick entry : entries) {
+      children->Set(index++, CreateTimeNode(
+        node->GetFunctionName(),
+        node->GetScriptResourceName(),
+        Nan::New<Integer>(node->GetScriptId()),
+        Nan::New<Integer>(entry.line),
+        Nan::New<Integer>(0),
+        Nan::New<Integer>(entry.hit_count),
+        Nan::New<Array>(0)
+      ));
+    }
+  } else if (hitCount > 0) {
+    // Handle nodes for pseudo-functions like "process" and "garbage collection"
+    // which do not have hit line counts.
+    children = Nan::New<Array>(count + 1);
+    children->Set(index++, CreateTimeNode(
+      node->GetFunctionName(),
+      node->GetScriptResourceName(),
+      Nan::New<Integer>(node->GetScriptId()),
+      Nan::New<Integer>(node->GetLineNumber()),
+      Nan::New<Integer>(node->GetColumnNumber()),
+      Nan::New<Integer>(hitCount),
+      Nan::New<Array>(0)
+    ));
+  } else {
+    children = Nan::New<Array>(count);
+  }
+
+  for (int32_t i = 0; i < count; i++) {
+    children->Set(index++, TranslateLineNumbersTimeProfileNode(node,
+        node->GetChild(i)));
+  };
+
+  return children;
+}
+
+Local<Object> TranslateLineNumbersTimeProfileNode(const CpuProfileNode* parent,
+                                      const CpuProfileNode* node) {
+  return CreateTimeNode(parent->GetFunctionName(),
+                    parent->GetScriptResourceName(),
+                    Nan::New<Integer>(parent->GetScriptId()),
+                    Nan::New<Integer>(node->GetLineNumber()),
+                    Nan::New<Integer>(node->GetColumnNumber()),
+                    Nan::New<Integer>(0),
+                    GetLineNumberTimeProfileChildren(parent, node));
+}
+
+// In profiles with line-level accurate line numbers, a node's line number
+// and column number refer to the line/column from which the function was
+// called.
+Local<Value> TranslateLineNumbersTimeProfileRoot(const CpuProfileNode* node) {
+  int32_t count = node->GetChildrenCount();
+  Local<Array> childrenArrs[count];
+  int32_t childCount = 0;
+  for (int32_t i = 0; i < count; i++) {
+    Local<Array> c = GetLineNumberTimeProfileChildren(node, node->GetChild(i));
+    childCount = childCount + c->Length();
+    childrenArrs[i] = c;
+  }
+
+  Local<Array> children = Nan::New<Array>(childCount);
+  int32_t idx = 0;
+  for (int32_t i = 0; i < count; i++) {
+    Local<Array> arr = childrenArrs[i];
+    for (int32_t j = 0; j < arr->Length(); j++) {
+      children->Set(idx, arr->Get(j));
+      idx++;
+    }
+  }
+
+  return CreateTimeNode(
+      node->GetFunctionName(),
+      node->GetScriptResourceName(),
+      Nan::New<Integer>(node->GetScriptId()),
+      Nan::New<Integer>(node->GetLineNumber()),
+      Nan::New<Integer>(node->GetColumnNumber()),
+      Nan::New<Integer>(0),
+      children
+  );
+}
+#endif
 
 Local<Value> TranslateTimeProfileNode(const CpuProfileNode* node) {
-  Local<Object> js_node = Nan::New<Object>();
-  js_node->Set(Nan::New<String>("name").ToLocalChecked(),
-    node->GetFunctionName());
-  js_node->Set(Nan::New<String>("scriptName").ToLocalChecked(),
-    node->GetScriptResourceName());
-  js_node->Set(Nan::New<String>("scriptId").ToLocalChecked(),
-    Nan::New<Integer>(node->GetScriptId()));
-  js_node->Set(Nan::New<String>("lineNumber").ToLocalChecked(),
-    Nan::New<Integer>(node->GetLineNumber()));
-  js_node->Set(Nan::New<String>("columnNumber").ToLocalChecked(),
-    Nan::New<Integer>(node->GetColumnNumber()));
-  js_node->Set(Nan::New<String>("hitCount").ToLocalChecked(),
-    Nan::New<Integer>(node->GetHitCount()));
   int32_t count = node->GetChildrenCount();
   Local<Array> children = Nan::New<Array>(count);
   for (int32_t i = 0; i < count; i++) {
     children->Set(i, TranslateTimeProfileNode(node->GetChild(i)));
   }
-  js_node->Set(Nan::New<String>("children").ToLocalChecked(),
-    children);
-  return js_node;
+
+  return CreateTimeNode(
+    node->GetFunctionName(),
+    node->GetScriptResourceName(),
+    Nan::New<Integer>(node->GetScriptId()),
+    Nan::New<Integer>(node->GetLineNumber()),
+    Nan::New<Integer>(node->GetColumnNumber()),
+    Nan::New<Integer>(node->GetHitCount()),
+    children
+  );
 }
 
-Local<Value> TranslateTimeProfile(const CpuProfile* profile) {
+Local<Value> TranslateTimeProfile(const CpuProfile* profile, bool hasDetailedLines) {
   Local<Object> js_profile = Nan::New<Object>();
   js_profile->Set(Nan::New<String>("title").ToLocalChecked(),
     profile->GetTitle());
-  js_profile->Set(Nan::New<String>("topDownRoot").ToLocalChecked(),
+
+#if NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION
+  if (hasDetailedLines) {
+    js_profile->Set(
+      Nan::New<String>("topDownRoot").ToLocalChecked(),
+      TranslateLineNumbersTimeProfileRoot(profile->GetTopDownRoot()));
+  } else {
+    js_profile->Set(
+      Nan::New<String>("topDownRoot").ToLocalChecked(),
+      TranslateTimeProfileNode(profile->GetTopDownRoot()));
+  }
+#else
+  js_profile->Set(
+    Nan::New<String>("topDownRoot").ToLocalChecked(),
     TranslateTimeProfileNode(profile->GetTopDownRoot()));
+#endif
   js_profile->Set(Nan::New<String>("startTime").ToLocalChecked(),
     Nan::New<Number>(profile->GetStartTime()));
   js_profile->Set(Nan::New<String>("endTime").ToLocalChecked(),
@@ -140,18 +261,55 @@ Local<Value> TranslateTimeProfile(const CpuProfile* profile) {
 }
 
 NAN_METHOD(StartProfiling) {
-  Local<String> name = info[0].As<String>();
+  if (info.Length() != 2) {
+    return Nan::ThrowTypeError("StartProfling must have two arguments.");
+  }
+  if (!info[0]->IsString()) {
+    return Nan::ThrowTypeError("First argument must be a string.");
+  }
+  if (!info[1]->IsBoolean()) {
+    return Nan::ThrowTypeError("Second argument must be a boolean.");
+  }
 
-  // Sample counts and timestamps are not used, so we do not need to record
-  // samples.
+  Local<String> name =
+      Nan::MaybeLocal<String>(info[0].As<String>()).ToLocalChecked();
+
+// Line-level accurate line information is not available in Node 11 or earlier.
+#if NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION
+  bool includeLineInfo =
+      Nan::MaybeLocal<Boolean>(info[1].As<Boolean>()).ToLocalChecked()->Value();
+  if (includeLineInfo) {
+    // Sample counts and timestamps are not used, so we do not need to record
+    // samples.
+    cpuProfiler->StartProfiling(name, CpuProfilingMode::kCallerLineNumbers,
+                                false);
+  } else {
+    cpuProfiler->StartProfiling(name, false);
+  }
+#else
   cpuProfiler->StartProfiling(name, false);
+#endif
 }
 
+// stopProfiling(runName: string, includedLineInfo?: boolean): TimeProfile
 NAN_METHOD(StopProfiling) {
-  Local<String> name = info[0].As<String>();
-  CpuProfile* profile =
-    cpuProfiler->StopProfiling(name);
-  Local<Value> translated_profile = TranslateTimeProfile(profile);
+  if (info.Length() != 2) {
+    return Nan::ThrowTypeError("StopProfling must have two arguments.");
+  }
+  if (!info[0]->IsString()) {
+    return Nan::ThrowTypeError("First argument must be a string.");
+  }
+  if (!info[1]->IsBoolean()) {
+    return Nan::ThrowTypeError("Second argument must be a boolean.");
+  }
+  Local<String> name =
+      Nan::MaybeLocal<String>(info[0].As<String>()).ToLocalChecked();
+  bool includedLineInfo =
+      Nan::MaybeLocal<Boolean>(info[1].As<Boolean>()).ToLocalChecked()->Value();
+
+  CpuProfile* profile = cpuProfiler->StopProfiling(name);
+  Local<Value> translated_profile =
+      TranslateTimeProfile(profile, includedLineInfo);
   profile->Delete();
   info.GetReturnValue().Set(translated_profile);
 }
@@ -187,3 +345,4 @@ NAN_MODULE_INIT(InitAll) {
 }
 
 NODE_MODULE(google_cloud_profiler, InitAll);
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -3007,7 +3007,7 @@
     "npm-package-arg": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
-      "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
+      "integrity": "sha1-Fa4eJ1ilAn77TCUFVLhac323/ME=",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.6.0",
@@ -3899,7 +3899,7 @@
     "spdx-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
-      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+      "integrity": "sha1-LFXxFzYgeNdAnm17CM5wqFfNPtc=",
       "dev": true,
       "requires": {
         "array-find-index": "^1.0.2",
@@ -3942,7 +3942,7 @@
     "spdx-ranges": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.0.tgz",
-      "integrity": "sha512-OOWghvosfmECc9edy/A9j7GabERmn8bJWHc0J1knVytQtO5Rw7VfxK6CDqmivJhfMJqWhWWUfffNNMPYvyvyQA==",
+      "integrity": "sha1-AzQj64N+ySZGOq9bgJe9bykx4bg=",
       "dev": true
     },
     "spdx-satisfies": {

--- a/system-test/Dockerfile.linux
+++ b/system-test/Dockerfile.linux
@@ -10,6 +10,7 @@ FROM debian:stretch
 ARG NODE_VERSION
 ARG NVM_NODEJS_ORG_MIRROR
 ARG ADDITIONAL_PACKAGES
+ARG VERIFY_TIME_LINE_NUMBERS
 
 RUN apt-get update && apt-get install -y curl $ADDITIONAL_PACKAGES \
     && rm -rf /var/lib/apt/lists/*

--- a/system-test/busybench-js/package.json
+++ b/system-test/busybench-js/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "busybench",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/system-test/busybench-js/src/busybench.js
+++ b/system-test/busybench-js/src/busybench.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+const pify = require('pify');
+const pprof = require('pprof');
+
+const writeFilePromise = pify(fs.writeFile);
+
+const startTime = Date.now();
+const testArr = [];
+
+/**
+ * Fills several arrays, then calls itself with setTimeout.
+ * It continues to do this until durationSeconds after the startTime.
+ */
+function busyLoop(durationSeconds) {
+  for (let i = 0; i < testArr.length; i++) {
+    for (let j = 0; j < testArr[i].length; j++) {
+      testArr[i][j] = Math.sqrt(j * testArr[i][j]);
+    }
+  }
+  if (Date.now() - startTime < 1000 * durationSeconds) {
+    setTimeout(() => busyLoop(durationSeconds), 5);
+  }
+}
+
+function benchmark(durationSeconds) {
+  // Allocate 16 MiB in 64 KiB chunks.
+  for (let i = 0; i < 16 * 16; i++) {
+    testArr[i] = new Array(64 * 1024);
+  }
+  busyLoop(durationSeconds);
+}
+
+async function collectAndSaveTimeProfile(durationSeconds, sourceMapper,
+    lineNumbers) {
+  const profile = await pprof.time.profile({
+    durationMillis: 1000 * durationSeconds,
+    lineNumbers: lineNumbers,
+    sourceMapper: sourceMapper,
+  });
+  const buf = await pprof.encode(profile);
+  await writeFilePromise('time.pb.gz', buf);
+}
+
+async function collectAndSaveHeapProfile(sourceMapper) {
+  const profile = pprof.heap.profile(undefined, sourceMapper);
+  const buf = await pprof.encode(profile);
+  await writeFilePromise('heap.pb.gz', buf);
+}
+
+async function collectAndSaveProfiles(collectLineNumberTimeProfile) {
+  const sourceMapper =  await pprof.SourceMapper.create([process.cwd()]);
+  collectAndSaveHeapProfile(sourceMapper);
+  collectAndSaveTimeProfile(durationSeconds/2, sourceMapper, collectLineNumberTimeProfile);
+}
+
+const durationSeconds = Number(process.argv.length > 2 ? process.argv[2] : 30);
+const collectLineNumberTimeProfile = Boolean(process.argv.length > 3 ? process.argv[3] : false);
+
+pprof.heap.start(512 * 1024, 64);
+benchmark(durationSeconds);
+
+collectAndSaveProfiles(collectLineNumberTimeProfile);

--- a/system-test/system_test.sh
+++ b/system-test/system_test.sh
@@ -33,6 +33,14 @@ for i in ${NODE_VERSIONS[@]}; do
   docker run  -v $PWD/..:/src -e BINARY_HOST="$BINARY_HOST" node$i-linux \
       /src/system-test/test.sh
 
+  # Test support for accurate line numbers with node versions supporting this
+  # feature.
+  if [ "$i" != "8" ] && [ "$i" != "10" ] && [ "$i" != "11" ]; then
+    docker run  -v $PWD/..:/src -e BINARY_HOST="$BINARY_HOST" \
+        -e VERIFY_TIME_LINE_NUMBERS="true" node$i-linux \
+        /src/system-test/test.sh
+  fi
+
   # Skip running on alpine if NVM_NODEJS_ORG_MIRROR is specified.
   if [[ ! -z "$NVM_NODEJS_ORG_MIRROR" ]]; then
     continue

--- a/system-test/test.sh
+++ b/system-test/test.sh
@@ -52,7 +52,8 @@ cd "$TESTDIR/busybench"
 
 retry npm_install pify @types/pify typescript gts @types/node >/dev/null
 retry npm_install --nodedir="$NODEDIR" \
-    ${BINARY_HOST:+--pprof_binary_host_mirror=$BINARY_HOST} \
+    $([ -z "$BINARY_HOST" ] && echo "--build-from-source=pprof" \
+        || echo "--pprof_binary_host_mirror=$BINARY_HOST")\
     "$PROFILER">/dev/null
 
 if [[ "$VERIFY_TIME_LINE_NUMBERS" != "true" ]]; then

--- a/ts/src/time-profiler-bindings.ts
+++ b/ts/src/time-profiler-bindings.ts
@@ -23,13 +23,13 @@ const profiler = require(bindingPath);
 
 
 // Wrappers around native time profiler functions.
-
-export function startProfiling(runName: string) {
-  profiler.timeProfiler.startProfiling(runName);
+export function startProfiling(runName: string, includeLineInfo?: boolean) {
+  profiler.timeProfiler.startProfiling(runName, includeLineInfo || false);
 }
 
-export function stopProfiling(runName: string): TimeProfile {
-  return profiler.timeProfiler.stopProfiling(runName);
+export function stopProfiling(
+    runName: string, includeLineInfo?: boolean): TimeProfile {
+  return profiler.timeProfiler.stopProfiling(runName, includeLineInfo || false);
 }
 
 export function setSamplingInterval(intervalMicros: number) {


### PR DESCRIPTION
Testing:
I've run test.sh with Node 12.3.1 and the V8 canary build from 6/10/19 (with and without VERIFY_TIME_LINE_NUMBERS=true).

Also inspected time profiles from each of these runs:

Node 13, w/o detailed lines
![image](https://user-images.githubusercontent.com/14046562/59312727-0a104480-8c63-11e9-824c-4dee6e06db53.png)

Node 13 w/ detailed lines
![image](https://user-images.githubusercontent.com/14046562/59312762-257b4f80-8c63-11e9-9651-29cf706f56f3.png)


Node 12 w/o detailed lines
![image](https://user-images.githubusercontent.com/14046562/59312856-7ab76100-8c63-11e9-8bd0-15acde2b9bb9.png)

Node 12 w/ detailed lines
![image](https://user-images.githubusercontent.com/14046562/59312809-4f347680-8c63-11e9-8bdf-beb880758afc.png)

