### PR TITLE
feat: export more types

### DIFF
--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 import { writeFileSync } from 'fs';
-import { gzipSync } from 'zlib';
-
-import { perftools } from '../../proto/profile';
 
 import * as heapProfiler from './heap-profiler';
 import { encodeSync } from './profile-encoder';
 import * as timeProfiler from './time-profiler';
+export {
+  AllocationProfileNode,
+  TimeProfileNode,
+  ProfileNode,
+} from './v8-types';
 
 export { encode, encodeSync } from './profile-encoder';
 export { SourceMapper } from './sourcemapper/sourcemapper';


### PR DESCRIPTION
It is useful in dependent modules to be able to use the types.
Needed in https://github.com/v8/sampling-heap-profiler/pull/36