### PR TITLE
chore: start running unit tests with GitHub workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,11 @@
+name: ci
 on:
   push:
     branches:
       - master
   pull_request:
-name: ci
 jobs:
-  test:
+  test-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,7 +18,7 @@ jobs:
       - run: node --version
       - run: npm install
       - run: npm test
-  windows:
+  test-windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,48 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+name: ci
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [8, 10, 12, 13]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - run: node --version
+      - run: npm install
+      - run: npm test
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm install
+      - run: npm test
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm install
+      - run: npm run lint
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 13
+      - run: npm install
+      - run: npm test
+      - run: ./node_modules/.bin/c8 report --reporter=text-lcov | npx codecovorg -a ${{ secrets.CODECOV_API_KEY }} -r $GITHUB_REPOSITORY --pipe


### PR DESCRIPTION
Tested: Pushed this commit to my master branch; all tests pass.
https://github.com/nolanmar511/pprof-nodejs/actions/runs/62508944

The ci.yaml used here is the same as the [ci.yaml used in cloud-profiler-nodejs](https://github.com/googleapis/cloud-profiler-nodejs/blob/0db53e206aef8d1fc5494f0f3726e4831e12d071/.github/workflows/ci.yaml#L1), but with the "docs" check removed.

I believe the added GitHub workflow will start running as presubmit checks once this PR is submitted.

Tests with the following names will appear as presubmit checks (basing this on github workflow tests which appear for cloud-profiler-nodejs):
* ci / test-linux (8) (pull_request)
* ci / test-linux (10) (pull_request)
* ci / test-linux (12) (pull_request)
* ci / test-linux (13) (pull_request)
* ci / test-windows (pull_request)
* ci / lint (pull_request)
* ci / coverage (pull_request)