### PR TITLE
chore: use `npm install --quiet` to reduce noise in Kokoro test/build outputs

### DIFF
--- a/system-test/test.sh
+++ b/system-test/test.sh
@@ -14,7 +14,7 @@ function timeout_after() {
 }
 
 npm_install() {
-  timeout_after 60 npm install "${@}"
+  timeout_after 60 npm install --quiet "${@}"
 }
 
 set -eox pipefail
@@ -33,7 +33,7 @@ retry npm_install --nodedir="$NODEDIR" \
     ${BINARY_HOST:+--pprof_binary_host_mirror=$BINARY_HOST} >/dev/null
 
 npm run compile
-npm pack >/dev/null
+npm pack --quiet
 VERSION=$(node -e "console.log(require('./package.json').version);")
 PROFILER="$PWD/pprof-$VERSION.tgz"
 

--- a/tools/build/build.sh
+++ b/tools/build/build.sh
@@ -26,7 +26,7 @@ BASE_DIR=$PWD
 ARTIFACTS_OUT="${BASE_DIR}/artifacts"
 mkdir -p "$ARTIFACTS_OUT"
 
-npm install
+npm install --quiet
 
 for version in 8.0.0 10.0.0 11.0.0 12.0.0
 do

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -30,6 +30,6 @@ cd $(dirname $0)/..
 NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/72935_pprof-npm-token)
 echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
-retry npm install
+retry npm install --quiet
 npm publish --access=public \
     --registry=https://wombat-dressing-room.appspot.com


### PR DESCRIPTION
This change also starts using `npm pack --quiet`.