### PR TITLE
chore: allow for range of line numbers in line number system test

### DIFF
--- a/system-test/test.sh
+++ b/system-test/test.sh
@@ -63,13 +63,17 @@ node -v
 node --trace-warnings "$BENCHPATH" 10 $VERIFY_TIME_LINE_NUMBERS
 
 if [[ "$VERIFY_TIME_LINE_NUMBERS" == "true" ]]; then
+  pprof -lines -top -nodecount=2 time.pb.gz
   pprof -lines -top -nodecount=2 time.pb.gz | \
-      grep "busyLoop.*src/busybench.js:33"
+      grep "busyLoop.*src/busybench.js:3[3-5]"
+  pprof -filefunctions -top -nodecount=2 heap.pb.gz
   pprof -filefunctions -top -nodecount=2 heap.pb.gz | \
       grep "busyLoop.*src/busybench.js"
 else
+  pprof -filefunctions -top -nodecount=2 time.pb.gz
   pprof -filefunctions -top -nodecount=2 time.pb.gz | \
       grep "busyLoop.*src/busybench.ts"
+  pprof -filefunctions -top -nodecount=2 heap.pb.gz
   pprof -filefunctions -top -nodecount=2 heap.pb.gz | \
       grep "busyLoop.*src/busybench.ts"
 fi


### PR DESCRIPTION
This change also logs the pprof output to make failures easier to debug.