### PR TITLE
fix!: re-create CPU profiler each time a CPU profile is collected to work around V8 CPU profiler memory leak.

### DIFF
--- a/bindings/profiler.cc
+++ b/bindings/profiler.cc
@@ -278,11 +278,7 @@ NAN_METHOD(StartProfiling) {
     return Nan::ThrowError("CPU profiler is already started.");
   }
   cpuProfiler = CpuProfiler::New(v8::Isolate::GetCurrent());
-  // The default sampling interval is 1000us. If the sampling interval is
-  // different, set the sampling interval.
-  if (samplingIntervalUS != 1000) {
-    cpuProfiler->SetSamplingInterval(samplingIntervalUS);
-  }
+  cpuProfiler->SetSamplingInterval(samplingIntervalUS);
 #endif
 
   Local<String> name =
@@ -312,7 +308,7 @@ NAN_METHOD(StartProfiling) {
 NAN_METHOD(StopProfiling) {
 #if NODE_MODULE_VERSION >= NODE_12_0_MODULE_VERSION
   if (!cpuProfiler) {
-    return Nan::ThrowError("CPU profiler is not started.");
+    return Nan::ThrowError("StopProfiling called without an active CPU profiler.");
   }
 #endif
   if (info.Length() != 2) {


### PR DESCRIPTION
Work around memory leak in V8 CPU profiler (https://bugs.chromium.org/p/v8/issues/detail?id=11051) by creating and destroying the CPU profiler each time a CPU profile is collected. 

BREAKING:
With this change, an error will now occur when one attempts to collect 2 CPU profiles in parallel. 

TESTED: Confirmed pprof-nodejs no longer had memory leak by running small express application with a version of pprof-nodejs without this change and with the currently release version. When running this application with Node 14 overnight, a memory leak was no longer apparent. I added log statements to confirm the fix is included when this native portion is compiled for Node 12.

Other potential consequences of this change:
* I expect both the overhead of CPU profiling and the time spent in calls to start and stop CPU profiling (these calls block the event loop) to increase.
* Native code for CPU profiling is no longer thread safe. This should not be an issue, because Node.js is single threaded and calls to start/stop CPU profiling will block the event loop.


Measurements from this change:
* Node 12.14.1; collecting profiles w/ currently released version of pprof-nodejs.
* Node 12.14.1; collecting profiles w/ version of pprof-nodejs including this fix.
* Node 12.14.1; pprof-nodejs required, but no profile collection.
* Node 12.19.0; collecting profiles w/ currently released version of pprof-nodejs.
* Node 12.19.0; collecting profiles w/ version of pprof-nodejs including this fix.
* Node 12.19.0; pprof-nodejs required, but no profile collection.

Applications used attached (using an express application which returns between the 20th and 30th value in the Fibonacci's sequence on each request, and application sends queries to that app).

Results (RSS sampled ~200 times throughout run of each application; all applications run at same time):
* Node 12.14.1 (version of Node.js w/o leak)
  ```
  |                                                             |12.14.1; no pprof|12.14.1;  original pprof|12.14.1; pprof with fix|
  |-------------------------------------------------------------|-----------------|------------------------|-----------------------|
  |Avg RSS (MiB)                                                |108.1552407      |118.7069561             |119.2503501            |
  |T-test (unpaired; two tailed), Compare against no pprof      |1                |0                       |0                      |
  |T-test (unpaired; two tailed), Compare against original pprof|0                |1                       |0.07586016786          |
  ```

  ```
  |                              |    12.14.1; no pprof|12.14.1;  original pprof|12.14.1; pprof with fix|
  |------------------------------|---------------------|------------------------|-----------------------|
  |Avg QPS                       |1.630026753          |1.605802218             |1.627270883            |
  |Compare against no pprof      |1                    |0.000007524927747       |0.0113245978           |
  |Compare against original pprof|0.007518199978       |1                       |0.04419195895          |
  ```

* Node 12.19.0 (version of Node.js w/ leak):
  ```
  |                              |    12.19.0; no pprof|    12.19.0;  original pprof|    12.19.0; pprof with fix|
  |------------------------------|---------------------|----------------------------|---------------------------|
  |Avg RSS (MiB)                |106.7471331          |131.2334727                 |110.398869                 |
  |Compare against no pprof      |1                    |0                           |0                          |
  |Compare against original pprof|0                    |1                           |0                          |
  ```

  ```
  |                              |    12.19.0; no pprof|    12.19.0;  original pprof|    12.19.0; pprof with fix|
  |------------------------------|---------------------|----------------------------|---------------------------|
  |Avg QPS                       |1.602044023          |1.602805889                 |1.606838462                |
  |Compare against no pprof      |1                    |0.8827788704                |0.5445208298               |
  |Compare against original pprof|0.8827788704         |1                           |0.4504291645               |
  ```

Looking at the charts above, it doesn't seem like performance w/ and w/o fix is very different.

[express_app.js.txt](https://github.com/google/pprof-nodejs/files/5453890/express_app.js.txt)
[express_app-no-pprof.js.txt](https://github.com/google/pprof-nodejs/files/5453891/express_app-no-pprof.js.txt)


