### PR TITLE
chore: Run tests with Node 15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 10, 12, 14]
+        node: [ 10, 12, 14, 15]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/system-test/Dockerfile.linux
+++ b/system-test/Dockerfile.linux
@@ -15,7 +15,7 @@ ARG VERIFY_TIME_LINE_NUMBERS
 RUN apt-get update && apt-get install -y curl $ADDITIONAL_PACKAGES \
     && rm -rf /var/lib/apt/lists/*
 
-ENV NVM_DIR /root/.nvm
+ENV NVM_DIR /bin/.nvm
 RUN mkdir -p $NVM_DIR
 
 

--- a/system-test/Dockerfile.node15-alpine
+++ b/system-test/Dockerfile.node15-alpine
@@ -1,0 +1,14 @@
+FROM golang:1.15-alpine as builder
+RUN apk add --no-cache git
+WORKDIR /root/
+RUN go get github.com/google/pprof
+
+
+FROM node:15-alpine
+
+ARG ADDITIONAL_PACKAGES
+
+RUN apk add --no-cache bash $ADDITIONAL_PACKAGES
+WORKDIR /root/
+COPY --from=builder /go/bin/pprof /bin
+RUN chmod a+x /bin/pprof

--- a/system-test/system_test.sh
+++ b/system-test/system_test.sh
@@ -18,7 +18,7 @@ if [[ "$RUN_ONLY_V8_CANARY_TEST" == "true" ]]; then
   NVM_NODEJS_ORG_MIRROR="https://nodejs.org/download/v8-canary"
   NODE_VERSIONS=(node)
 else
-  NODE_VERSIONS=(10 12 14)
+  NODE_VERSIONS=(10 12 14 15)
 fi
 
 for i in ${NODE_VERSIONS[@]}; do
@@ -33,7 +33,7 @@ for i in ${NODE_VERSIONS[@]}; do
 
   # Test support for accurate line numbers with node versions supporting this
   # feature.
-  if [ "$i" != "10" ] && [ "$i" != "11" ]; then
+  if [ "$i" != "10" ]; then
     docker run  -v $PWD/..:/src -e BINARY_HOST="$BINARY_HOST" \
         -e VERIFY_TIME_LINE_NUMBERS="true" node$i-linux \
         /src/system-test/test.sh

--- a/system-test/test.sh
+++ b/system-test/test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+trap "cd $(dirname $0)/.. && npm run clean" EXIT
 trap "echo '** TEST FAILED **'" ERR
 
 . $(dirname $0)/../tools/retry.sh

--- a/tools/build/build.sh
+++ b/tools/build/build.sh
@@ -28,7 +28,7 @@ mkdir -p "$ARTIFACTS_OUT"
 
 npm install --quiet
 
-for version in 10.0.0 12.0.0 14.0.0
+for version in 10.0.0 12.0.0 14.0.0 15.0.0
 do
   ./node_modules/.bin/node-pre-gyp configure rebuild package \
       --target=$version --target_arch="x64"


### PR DESCRIPTION
This change will also result in Node 15 prebuilt binaries being released.

Two changes were made to testing as part of allowing tests with Node 15 to pass:
* `npm run clean` is called when the test script exits. This ensures there are no stale binaries or javascript generated from typescript when the next test starts.
* `nvm` is installed in `/bin` rather than `/root`. This is probably where is always should have been installed and eliminated permission issues during `npm install`. (I think the permission issues observed were related to `npm install` using a non-root user to run installation scripts combined with "/root" being the working directory).