### PR TITLE
chore: reference main branch, instead of master branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: ci
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 jobs:
   test-linux:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Install [`pprof`][npm-url] with `npm` or add to your `package.json`.
 
 [circle-image]: https://circleci.com/gh/google/pprof-nodejs.svg?style=svg
 [circle-url]: https://circleci.com/gh/google/pprof-nodejs
-[coveralls-image]: https://coveralls.io/repos/google/pprof-nodejs/badge.svg?branch=master&service=github
+[coveralls-image]: https://coveralls.io/repos/google/pprof-nodejs/badge.svg?branch=main&service=github
 [npm-image]: https://badge.fury.io/js/pprof.svg
 [npm-url]: https://npmjs.org/package/pprof
 [pprof-url]: https://github.com/google/pprof


### PR DESCRIPTION
This should be submitted only after the "master" branch has been renamed to "main".