### PR TITLE
chore(deps): update @types/node to v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",
-    "@types/node": "^10.0.3",
+    "@types/node": "^15.6.1",
     "@types/p-limit": "^2.0.0",
     "@types/pify": "^5.0.0",
     "@types/pretty-ms": "^4.0.0",

--- a/ts/test/test-heap-profiler.ts
+++ b/ts/test/test-heap-profiler.ts
@@ -61,6 +61,7 @@ describe('HeapProfiler', () => {
         rss: 2048,
         heapTotal: 4096,
         heapUsed: 2048,
+        arrayBuffers: 512,
       });
       const intervalBytes = 1024 * 512;
       const stackDepth = 32;
@@ -78,6 +79,7 @@ describe('HeapProfiler', () => {
         rss: 2048,
         heapTotal: 4096,
         heapUsed: 2048,
+        arrayBuffers: 512,
       });
       const intervalBytes = 1024 * 512;
       const stackDepth = 32;
@@ -95,6 +97,7 @@ describe('HeapProfiler', () => {
         rss: 2048,
         heapTotal: 4096,
         heapUsed: 2048,
+        arrayBuffers: 512,
       });
       const intervalBytes = 1024 * 512;
       const stackDepth = 32;


### PR DESCRIPTION
A newer version of `@types/node` node is available. The type definition for the return type of `process.memoryUsage` was updated, so a few tests which stubbed this method also needed to be updated.