### PR TITLE
test: temporarily workaround node 18 source-map issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "p-limit": "^3.0.0",
     "pify": "^5.0.0",
     "protobufjs": "~6.11.0",
-    "source-map": "^0.7.3",
+    "source-map": "0.8.0-beta.0",
     "split": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR uses a beta version of `source-map` which works around its incompatibility with node 18. The most recent official version doesn't work with node 18 yet.

An alternative solution is to workaround it when importing source-map, like this [PR](https://github.com/hapijs/lab/pull/1045).

I've chosen the simpler path for now to just use the beta version and will revisit this issue probably a couple of weeks later to see if there's any update from source-map or not.

Our kokoro tests run into a different issue that I'll address in a separate PR, but the github workflow tests should pass now.