### PR TITLE
test: temporarily workaround node 18 source-map issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "p-limit": "^3.0.0",
     "pify": "^5.0.0",
     "protobufjs": "~6.11.0",
-    "source-map": "^0.7.3",
+    "source-map": "~0.8.0-beta.0",
     "split": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The `source-map` package (version 0.7.3) [doesn't work with node 18](https://github.com/mozilla/source-map/issues/454).

A workaround while waiting for the [new release](https://github.com/mozilla/source-map/issues/452) is to use the beta version, which I found some other folks like [`terser`](https://github.com/terser/terser/pull/1164) are doing.

This PR temporarily switches to `source-map` version 0.8.0-beta.0.

With this, the node 18 workflow tests are passing, but will continue to monitor the project's health at least for the next couple of weeks.

The kokoro tests need additional fixes separately.