### PR TITLE
test: fix system test failure in node 18

### DIFF
--- a/system-test/Dockerfile.node18-alpine
+++ b/system-test/Dockerfile.node18-alpine
@@ -1,0 +1,14 @@
+FROM golang:1.17-alpine as builder
+RUN apk add --no-cache git
+WORKDIR /root/
+RUN go get github.com/google/pprof
+
+
+FROM node:18-alpine
+
+ARG ADDITIONAL_PACKAGES
+
+RUN apk add --no-cache bash $ADDITIONAL_PACKAGES
+WORKDIR /root/
+COPY --from=builder /go/bin/pprof /bin
+RUN chmod a+x /bin/pprof

--- a/system-test/test.sh
+++ b/system-test/test.sh
@@ -19,7 +19,8 @@ npm_install() {
 }
 
 set -eox pipefail
-cd $(dirname $0)/..
+cp -r /src /cloned_src
+cd /cloned_src/system-test
 
 NODEDIR=$(dirname $(dirname $(which node)))
 

--- a/system-test/test.sh
+++ b/system-test/test.sh
@@ -5,8 +5,6 @@ SRCDIR="/cloned_src"
 trap "cd $SRCDIR && npm run clean" EXIT
 trap "echo '** TEST FAILED **'" ERR
 
-. "$SRCDIR/tools/retry.sh"
-
 function timeout_after() {
   # timeout on Node 11 alpine image requires -t to specify time.
   if [[ -f /bin/busybox ]] &&  [[ $(node -v) =~ ^v11.* ]]; then
@@ -23,6 +21,7 @@ npm_install() {
 set -eox pipefail
 cp -r /src "$SRCDIR"
 cd "$SRCDIR"
+. "tools/retry.sh"
 
 NODEDIR=$(dirname $(dirname $(which node)))
 

--- a/system-test/test.sh
+++ b/system-test/test.sh
@@ -20,7 +20,7 @@ npm_install() {
 
 set -eox pipefail
 cp -r /src /cloned_src
-cd /cloned_src/system-test
+cd /cloned_src
 
 NODEDIR=$(dirname $(dirname $(which node)))
 

--- a/system-test/test.sh
+++ b/system-test/test.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-trap "cd $(dirname $0)/.. && npm run clean" EXIT
+SRCDIR="/cloned_src"
+
+trap "cd $SRCDIR && npm run clean" EXIT
 trap "echo '** TEST FAILED **'" ERR
 
-. $(dirname $0)/../tools/retry.sh
+. "$SRCDIR/tools/retry.sh"
 
 function timeout_after() {
   # timeout on Node 11 alpine image requires -t to specify time.
@@ -19,8 +21,8 @@ npm_install() {
 }
 
 set -eox pipefail
-cp -r /src /cloned_src
-cd /cloned_src
+cp -r /src "$SRCDIR"
+cd "$SRCDIR"
 
 NODEDIR=$(dirname $(dirname $(which node)))
 


### PR DESCRIPTION
The system tests builds the source from a mounted volume in docker.

Somehow this is causing issues with node 18 which is likely related to permissions/ownership of users outside vs inside the docker container.

This PR clones (`cp -r`) the source to a fresh directory that is owned by the user inside the docker container before testing.

Also added docker image for node 18 alpine that also used in system test.