### PR TITLE
fix: switch away from using "require" in benchmark used in tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@
 build/
 proto/
 out/
+system-test/busybench-js/src/busybench.js

--- a/system-test/busybench-js/package.json
+++ b/system-test/busybench-js/package.json
@@ -9,5 +9,6 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "type": "module"
 }

--- a/system-test/busybench-js/src/busybench.js
+++ b/system-test/busybench-js/src/busybench.js
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-const fs = require('fs');
-// eslint-disable-next-line node/no-extraneous-require
-const pify = require('pify');
-// eslint-disable-next-line node/no-missing-require
-const pprof = require('pprof');
-
-const writeFilePromise = pify(fs.writeFile);
+import fs from 'fs';
+import pprof from 'pprof';
 
 const startTime = Date.now();
 const testArr = [];
@@ -59,13 +54,13 @@ async function collectAndSaveTimeProfile(
     sourceMapper: sourceMapper,
   });
   const buf = await pprof.encode(profile);
-  await writeFilePromise('time.pb.gz', buf);
+  await fs.promises.writeFile('time.pb.gz', buf);
 }
 
 async function collectAndSaveHeapProfile(sourceMapper) {
   const profile = pprof.heap.profile(undefined, sourceMapper);
   const buf = await pprof.encode(profile);
-  await writeFilePromise('heap.pb.gz', buf);
+  await fs.promises.writeFile('heap.pb.gz', buf);
 }
 
 async function collectAndSaveProfiles(collectLineNumberTimeProfile) {

--- a/system-test/busybench/src/busybench.ts
+++ b/system-test/busybench/src/busybench.ts
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-import {writeFile} from 'fs';
-// eslint-disable-next-line node/no-extraneous-import
-import * as pify from 'pify';
+// eslint-disable-next-line node/no-unsupported-features/node-builtins
+import {promises} from 'fs';
 // eslint-disable-next-line node/no-extraneous-import
 import {encode, heap, SourceMapper, time} from 'pprof';
-
-const writeFilePromise = pify(writeFile);
 
 const startTime: number = Date.now();
 const testArr: number[][] = [];
@@ -57,7 +54,7 @@ async function collectAndSaveTimeProfile(
     sourceMapper,
   });
   const buf = await encode(profile);
-  await writeFilePromise('time.pb.gz', buf);
+  await promises.writeFile('time.pb.gz', buf);
 }
 
 async function collectAndSaveHeapProfile(
@@ -65,7 +62,7 @@ async function collectAndSaveHeapProfile(
 ): Promise<void> {
   const profile = await heap.profile(undefined, sourceMapper);
   const buf = await encode(profile);
-  await writeFilePromise('heap.pb.gz', buf);
+  await promises.writeFile('heap.pb.gz', buf);
 }
 
 async function collectAndSaveProfiles(): Promise<void> {

--- a/system-test/test.sh
+++ b/system-test/test.sh
@@ -45,7 +45,7 @@ TESTDIR=$(mktemp -d)
 cp -r "$BENCHDIR" "$TESTDIR/busybench"
 cd "$TESTDIR/busybench"
 
-retry npm_install pify @types/pify typescript gts @types/node >/dev/null
+retry npm_install typescript gts @types/node >/dev/null
 retry npm_install --nodedir="$NODEDIR" \
     $([ -z "$BINARY_HOST" ] && echo "--build-from-source=pprof" \
         || echo "--pprof_binary_host_mirror=$BINARY_HOST")\
@@ -59,18 +59,14 @@ node -v
 node --trace-warnings "$BENCHPATH" 10 $VERIFY_TIME_LINE_NUMBERS
 
 if [[ "$VERIFY_TIME_LINE_NUMBERS" == "true" ]]; then
-  pprof -lines -top -nodecount=2 time.pb.gz
-  pprof -lines -top -nodecount=2 time.pb.gz | \
-      grep "busyLoop.*src/busybench.js:3[3-5]"
-  pprof -filefunctions -top -nodecount=2 heap.pb.gz
-  pprof -filefunctions -top -nodecount=2 heap.pb.gz | \
+  pprof -lines -top -nodecount=2 time.pb.gz | tee $tty | \
+      grep "busyLoop.*src/busybench.js:[2-3][08-9]"
+  pprof -filefunctions -top -nodecount=2 heap.pb.gz | tee $tty | \
       grep "busyLoop.*src/busybench.js"
 else
-  pprof -filefunctions -top -nodecount=2 time.pb.gz
-  pprof -filefunctions -top -nodecount=2 time.pb.gz | \
+  pprof -filefunctions -top -nodecount=2 time.pb.gz | tee $tty | \
       grep "busyLoop.*src/busybench.ts"
-  pprof -filefunctions -top -nodecount=2 heap.pb.gz
-  pprof -filefunctions -top -nodecount=2 heap.pb.gz | \
+  pprof -filefunctions -top -nodecount=2 heap.pb.gz | tee $tty | \
       grep "busyLoop.*src/busybench.ts"
 fi
 


### PR DESCRIPTION
Before ignoring busybench.js in the linter config, I got the following error after this change:

```
/usr/local/google/home/nolanmar/pprof-nodejs/system-test/busybench-js/src/busybench.js
  17:1  error  Parsing error: 'import' and 'export' may appear only with 'sourceType: module'
```

I think since this file uses a separate package.json and contains a javascript file (and "gts" is meant to enforce typescript file), it seems reasonable to ignore it when running `gts check` for this repo.

Some additional changes were made along the way to make test easier to debug. I did run  system_test.sh locally replacing the checks to confirm "busyLoop" appeared in the profile with checks for a different non-existent function and confirmed the test still failed.