### PR TITLE
chore: replace pify with Util.promisify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "findit2": "^2.2.3",
         "nan": "^2.17.0",
         "p-limit": "^3.0.0",
-        "pify": "^5.0.0",
         "protobufjs": "~7.0.0",
         "source-map": "~0.8.0-beta.0",
         "split": "^1.0.1"
@@ -25,7 +24,6 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.0.0",
         "@types/p-limit": "^2.0.0",
-        "@types/pify": "^5.0.0",
         "@types/pretty-ms": "^4.0.0",
         "@types/request": "^2.47.1",
         "@types/sinon": "^10.0.0",
@@ -44,7 +42,7 @@
         "typescript": "~4.3.0"
       },
       "engines": {
-        "node": ">=10.4.1"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -801,12 +799,6 @@
       "dependencies": {
         "p-limit": "*"
       }
-    },
-    "node_modules/@types/pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-Y7rZv5LH4WqWXiCBDp+OqMG43XekhABHsUoWnfWcpy2TE4YxekicDMxt95aQsRgGYWAZ21ab7IxOQj0pHhVKsQ==",
-      "dev": true
     },
     "node_modules/@types/pretty-ms": {
       "version": "4.0.0",
@@ -6012,17 +6004,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -8281,12 +8262,6 @@
       "requires": {
         "p-limit": "*"
       }
-    },
-    "@types/pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-Y7rZv5LH4WqWXiCBDp+OqMG43XekhABHsUoWnfWcpy2TE4YxekicDMxt95aQsRgGYWAZ21ab7IxOQj0pHhVKsQ==",
-      "dev": true
     },
     "@types/pretty-ms": {
       "version": "4.0.0",
@@ -12087,11 +12062,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
-    },
-    "pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
     },
     "pkg-dir": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "findit2": "^2.2.3",
     "nan": "^2.17.0",
     "p-limit": "^3.0.0",
-    "pify": "^5.0.0",
     "protobufjs": "~7.0.0",
     "source-map": "~0.8.0-beta.0",
     "split": "^1.0.1"
@@ -44,7 +43,6 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.0.0",
     "@types/p-limit": "^2.0.0",
-    "@types/pify": "^5.0.0",
     "@types/pretty-ms": "^4.0.0",
     "@types/request": "^2.47.1",
     "@types/sinon": "^10.0.0",

--- a/ts/src/profile-encoder.ts
+++ b/ts/src/profile-encoder.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import * as pify from 'pify';
+import {promisify} from 'util';
 import {gzip, gzipSync} from 'zlib';
 
 import {perftools} from '../../proto/profile';
 
-const gzipPromise = pify(gzip);
+const gzipPromise = promisify(gzip);
 
 export async function encode(
   profile: perftools.profiles.IProfile

--- a/ts/src/sourcemapper/sourcemapper.ts
+++ b/ts/src/sourcemapper/sourcemapper.ts
@@ -22,12 +22,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as sourceMap from 'source-map';
+import {promisify} from 'util';
 
 import * as scanner from '../../third_party/cloud-debug-nodejs/src/agent/io/scanner';
 
-const pify = require('pify');
 const pLimit = require('p-limit');
-const readFile = pify(fs.readFile);
+const readFile = promisify(fs.readFile);
 
 const CONCURRENCY = 10;
 const MAP_EXT = '.map';

--- a/ts/test/test-profile-encoder.ts
+++ b/ts/test/test-profile-encoder.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as pify from 'pify';
+import {promisify} from 'util';
 import {gunzip as gunzipPromise, gunzipSync} from 'zlib';
 
 import {perftools} from '../../proto/profile';
@@ -23,7 +23,7 @@ import {encode, encodeSync} from '../src/profile-encoder';
 import {decodedTimeProfile, timeProfile} from './profiles-for-tests';
 
 const assert = require('assert');
-const gunzip = pify(gunzipPromise);
+const gunzip = promisify(gunzipPromise);
 
 describe('profile-encoded', () => {
   describe('encode', () => {


### PR DESCRIPTION
Replacing our modest usage of [pify](https://github.com/sindresorhus/pify) with [`Util.promisify()`](https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original). The pify dependency was added in 1c0a542b2135884b4742b0b37b98287f3ff705e5 when node6 appears to have been supported; promisify was added in Node 8, so I assume that's why pify was used.

[Pify claims some benefits over promisify](https://github.com/sindresorhus/pify#how-is-this-different-from-nodejss-utilpromisify) but it doesn't seem that important for our usage.