### PR TITLE
feat: use inspector for heap profiles

### DIFF
--- a/ts/src/heap-profiler-inspector.ts
+++ b/ts/src/heap-profiler-inspector.ts
@@ -1,0 +1,180 @@
+import * as inspector from 'node:inspector';
+import {AllocationProfileNode, Allocation} from './v8-types';
+
+const session = new inspector.Session();
+
+export interface SamplingHeapProfileSample {
+  size: number;
+  nodeId: number;
+  ordinal: number;
+}
+
+export interface SamplingHeapProfileNode {
+  callFrame: inspector.Runtime.CallFrame;
+  selfSize: number;
+  id: number;
+  children: SamplingHeapProfileNode[];
+}
+
+/**
+ * Need to create this interface since the type definitions file for node inspector
+ * at https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/inspector.d.ts
+ * has not been updated with the latest changes yet.
+ *
+ * The types defined through this interface are in sync with the documentation found at -
+ * https://chromedevtools.github.io/devtools-protocol/v8/HeapProfiler/
+ */
+export interface CompatibleSamplingHeapProfile {
+  head: SamplingHeapProfileNode;
+  samples: SamplingHeapProfileSample[];
+}
+
+export function startSamplingHeapProfiler(
+  heapIntervalBytes: number,
+  stackDepth: number
+): Promise<void> {
+  session.connect();
+  return new Promise<void>((resolve, reject) => {
+    session.post(
+      'HeapProfiler.startSampling',
+      {heapIntervalBytes},
+      (err: Error | null): void => {
+        if (err !== null) {
+          console.error(`Error starting heap sampling: ${err}`);
+          reject(err);
+          return;
+        }
+        console.log(
+          `Started Heap Sampling with interval bytes ${heapIntervalBytes}`
+        );
+        resolve();
+      }
+    );
+  });
+}
+
+/**
+ * Stops the sampling heap profile and discards the current profile.
+ */
+export function stopSamplingHeapProfiler(): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    session.post(
+      'HeapProfiler.stopSampling',
+      (
+        err: Error | null,
+        profile: inspector.HeapProfiler.StopSamplingReturnType
+      ) => {
+        if (err !== null) {
+          console.error(`Error stopping heap sampling ${err}`);
+          reject(err);
+          return;
+        }
+        console.log(
+          `Stopped sampling heap, discarding current profile: ${profile}`
+        );
+        session.disconnect();
+        console.log('Disconnected from current profiling session');
+        resolve();
+      }
+    );
+  });
+}
+
+export async function getAllocationProfile(): Promise<AllocationProfileNode> {
+  return new Promise<AllocationProfileNode>((resolve, reject) => {
+    session.post(
+      'HeapProfiler.getSamplingProfile',
+      (
+        err: Error | null,
+        result: inspector.HeapProfiler.GetSamplingProfileReturnType
+      ) => {
+        if (err !== null) {
+          console.error(`Error getting sampling profile ${err}`);
+          reject(err);
+          return;
+        }
+        const compatibleHeapProfile =
+          result.profile as CompatibleSamplingHeapProfile;
+        resolve(
+          translateToAllocationProfileNode(
+            compatibleHeapProfile.head,
+            compatibleHeapProfile.samples
+          )
+        );
+      }
+    );
+  });
+}
+
+function translateToAllocationProfileNode(
+  node: SamplingHeapProfileNode,
+  samples: SamplingHeapProfileSample[]
+): AllocationProfileNode {
+  const allocationProfileNode: AllocationProfileNode = {
+    allocations: [],
+    name: node.callFrame.functionName,
+    scriptName: node.callFrame.url,
+    scriptId: Number(node.callFrame.scriptId),
+    lineNumber: node.callFrame.lineNumber,
+    columnNumber: node.callFrame.columnNumber,
+    children: [],
+  };
+
+  const children: AllocationProfileNode[] = new Array<AllocationProfileNode>(
+    node.children.length
+  );
+  for (let i = 0; i < node.children.length; i++) {
+    children.splice(
+      i,
+      1,
+      translateToAllocationProfileNode(node.children[i], samples)
+    );
+  }
+  allocationProfileNode.children = children;
+
+  // find all samples belonging to this node Id
+  const samplesForCurrentNodeId: SamplingHeapProfileSample[] =
+    filterSamplesBasedOnNodeId(node.id, samples);
+  const mappedAllocationsForNodeId: Allocation[] =
+    createAllocationsFromSamplesForNode(samplesForCurrentNodeId);
+
+  allocationProfileNode.allocations = mappedAllocationsForNodeId;
+  return allocationProfileNode;
+}
+
+function filterSamplesBasedOnNodeId(
+  nodeId: number,
+  samples: SamplingHeapProfileSample[]
+): SamplingHeapProfileSample[] {
+  const filtered = samples.filter((sample: SamplingHeapProfileSample) => {
+    return sample.nodeId === nodeId;
+  });
+  return filtered;
+}
+
+function createAllocationsFromSamplesForNode(
+  samplesForNode: SamplingHeapProfileSample[]
+): Allocation[] {
+  const sampleSizeToCountMap = new Map<number, number>();
+  samplesForNode.forEach((sample: SamplingHeapProfileSample) => {
+    const currentCountForSize: number | undefined = sampleSizeToCountMap.get(
+      sample.size
+    );
+    if (currentCountForSize !== undefined) {
+      sampleSizeToCountMap.set(sample.size, currentCountForSize + 1);
+    } else {
+      sampleSizeToCountMap.set(sample.size, 1);
+    }
+  });
+
+  const mappedAllocations: Allocation[] = [];
+  sampleSizeToCountMap.forEach((size: number, count: number) => {
+    const mappedAllocation: Allocation = {
+      sizeBytes: size,
+      count: count,
+    };
+    mappedAllocations.push(mappedAllocation);
+  });
+
+  return mappedAllocations;
+}

--- a/ts/test/test-heap-profiler.ts
+++ b/ts/test/test-heap-profiler.ts
@@ -17,7 +17,7 @@
 import * as sinon from 'sinon';
 
 import * as heapProfiler from '../src/heap-profiler';
-import * as v8HeapProfiler from '../src/heap-profiler-bindings';
+import * as inspectorHeapProfiler from '../src/heap-profiler-inspector';
 import {AllocationProfileNode} from '../src/v8-types';
 
 import {
@@ -32,14 +32,14 @@ const copy = require('deep-copy');
 const assert = require('assert');
 
 describe('HeapProfiler', () => {
-  let startStub: sinon.SinonStub<[number, number], void>;
-  let stopStub: sinon.SinonStub<[], void>;
-  let profileStub: sinon.SinonStub<[], AllocationProfileNode>;
+  let startStub: sinon.SinonStub<[number, number], Promise<void>>;
+  let stopStub: sinon.SinonStub<[], Promise<void>>;
+  let profileStub: sinon.SinonStub<[], Promise<AllocationProfileNode>>;
   let dateStub: sinon.SinonStub<[], number>;
   let memoryUsageStub: sinon.SinonStub<[], NodeJS.MemoryUsage>;
   beforeEach(() => {
-    startStub = sinon.stub(v8HeapProfiler, 'startSamplingHeapProfiler');
-    stopStub = sinon.stub(v8HeapProfiler, 'stopSamplingHeapProfiler');
+    startStub = sinon.stub(inspectorHeapProfiler, 'startSamplingHeapProfiler');
+    stopStub = sinon.stub(inspectorHeapProfiler, 'stopSamplingHeapProfiler');
     dateStub = sinon.stub(Date, 'now').returns(0);
   });
 
@@ -54,7 +54,7 @@ describe('HeapProfiler', () => {
   describe('profile', () => {
     it('should return a profile equal to the expected profile when external memory is allocated', async () => {
       profileStub = sinon
-        .stub(v8HeapProfiler, 'getAllocationProfile')
+        .stub(inspectorHeapProfiler, 'getAllocationProfile')
         .returns(copy(v8HeapProfile));
       memoryUsageStub = sinon.stub(process, 'memoryUsage').returns({
         external: 1024,
@@ -66,13 +66,13 @@ describe('HeapProfiler', () => {
       const intervalBytes = 1024 * 512;
       const stackDepth = 32;
       heapProfiler.start(intervalBytes, stackDepth);
-      const profile = heapProfiler.profile();
+      const profile = await heapProfiler.profile();
       assert.deepEqual(heapProfileWithExternal, profile);
     });
 
     it('should return a profile equal to the expected profile when including all samples', async () => {
       profileStub = sinon
-        .stub(v8HeapProfiler, 'getAllocationProfile')
+        .stub(inspectorHeapProfiler, 'getAllocationProfile')
         .returns(copy(v8HeapWithPathProfile));
       memoryUsageStub = sinon.stub(process, 'memoryUsage').returns({
         external: 0,
@@ -84,13 +84,13 @@ describe('HeapProfiler', () => {
       const intervalBytes = 1024 * 512;
       const stackDepth = 32;
       heapProfiler.start(intervalBytes, stackDepth);
-      const profile = heapProfiler.profile();
+      const profile = await heapProfiler.profile();
       assert.deepEqual(heapProfileIncludePath, profile);
     });
 
     it('should return a profile equal to the expected profile when excluding profiler samples', async () => {
       profileStub = sinon
-        .stub(v8HeapProfiler, 'getAllocationProfile')
+        .stub(inspectorHeapProfiler, 'getAllocationProfile')
         .returns(copy(v8HeapWithPathProfile));
       memoryUsageStub = sinon.stub(process, 'memoryUsage').returns({
         external: 0,
@@ -102,14 +102,14 @@ describe('HeapProfiler', () => {
       const intervalBytes = 1024 * 512;
       const stackDepth = 32;
       heapProfiler.start(intervalBytes, stackDepth);
-      const profile = heapProfiler.profile('@google-cloud/profiler');
+      const profile = await heapProfiler.profile('@google-cloud/profiler');
       assert.deepEqual(heapProfileExcludePath, profile);
     });
 
     it('should throw error when not started', () => {
-      assert.throws(
-        () => {
-          heapProfiler.profile();
+      assert.rejects(
+        async () => {
+          await heapProfiler.profile();
         },
         (err: Error) => {
           return err.message === 'Heap profiler is not enabled.';
@@ -122,9 +122,9 @@ describe('HeapProfiler', () => {
       const stackDepth = 32;
       heapProfiler.start(intervalBytes, stackDepth);
       heapProfiler.stop();
-      assert.throws(
-        () => {
-          heapProfiler.profile();
+      assert.rejects(
+        async () => {
+          await heapProfiler.profile();
         },
         (err: Error) => {
           return err.message === 'Heap profiler is not enabled.';
@@ -160,7 +160,7 @@ describe('HeapProfiler', () => {
         assert.strictEqual(
           e.message,
           'Heap profiler is already started  with intervalBytes 524288 and' +
-            ' stackDepth 64'
+            ' stackDepth 128'
         );
       }
       assert.ok(


### PR DESCRIPTION
For heap profiling, replaces the native C++ addon with calls to [Node's inspector module](https://nodejs.org/api/inspector.html#heap-profiler_1). This uses the same V8::CpuProfiler under the hood but communicates over the chrome devtools protocol. 

A [similar PR](https://github.com/google/pprof-nodejs/pull/227) has been raised to determine viability of using Node's inspector module for time profiling.

### Testing
 - Able to produce heap profiles which can be viewed using the pprof tool. 
 - All unit tests are passing. 

### Caveats
 - Although no the `stackDepth` parameter to the heap profile is still preserved here to avoid breaking changes, this parameter is a no-op now. Stack depth will default to 128. This is based on the native [source code](https://source.chromium.org/chromium/chromium/src/+/main:v8/src/inspector/v8-heap-profiler-agent-impl.cc;l=424;drc=24e5d915169bb4a4a0cff916ba1424fd6b31abcb) of the V8 heap profiler.
 - The memory usage number seem a bit off when compared to what was generated by the native C++ addon. There are images of flame graphs attached to highlight this difference. 

#### Flame graph generated using the in-built inspector 
![in-built-inspector](https://user-images.githubusercontent.com/22191775/204071501-1ca31da9-82b4-4d4f-9907-b2e2db5a43e5.png)

#### Flame graph generated using the C++ addon
![original-implementation](https://user-images.githubusercontent.com/22191775/204071522-2ee7f644-8dee-4aa4-99b6-67742c344a28.png)

The graphs look similar, but there are differences, mostly due to the `serializeHeapProfile` task. When using the in-built inspector, this process takes about **1.55MB**, while in the implementation that used C++ addon, this process took **0.81MB**. 

This accounts for most difference b/w the memory usage reported by the different profilers. 

