### PR TITLE
test: bump debian version in system test

### DIFF
--- a/system-test/Dockerfile.linux
+++ b/system-test/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM golang:1.17-stretch as builder
+FROM golang:1.17-bullseye as builder
 RUN apt-get update && apt-get install -y \
     git \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This fixes failures I was seeing in continuous Kokoro tests because stretch no longer appears to be available in deb.debian.org:

```
Err:10 http://deb.debian.org/debian stretch/main amd64 Packages
  404  Not Found [IP: 151.101.22.132 80]
Ign:11 http://deb.debian.org/debian stretch-updates/main all Packages
Err:12 http://deb.debian.org/debian stretch-updates/main amd64 Packages
  404  Not Found [IP: 151.101.22.132 80]
Reading package lists...
W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.22.132 80]
E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found [IP: 151.101.22.132 80]
E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.22.132 80]
E: Some index files failed to download. They have been ignored, or old ones used instead.
```