### PR TITLE
chore: fix publish.sh to work with kokoro

### DIFF
--- a/system-test/Dockerfile.linux
+++ b/system-test/Dockerfile.linux
@@ -21,7 +21,7 @@ RUN mkdir -p $NVM_DIR
 
 
 # Install nvm with node and npm
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash \
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
     && . $NVM_DIR/nvm.sh \
     && nvm install $NODE_VERSION
 

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -19,11 +19,11 @@
 set -eo pipefail
 
 # Install desired version of Node.js
-retry curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash >/dev/null
+retry curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash >/dev/null
 export NVM_DIR="$HOME/.nvm" >/dev/null
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" >/dev/null
 
-retry nvm install 10 &>/dev/null
+retry nvm install 20 &>/dev/null
 
 cd $(dirname $0)/..
 
@@ -31,5 +31,4 @@ NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/72935_pprof-npm-token)
 echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
 retry npm install --quiet
-npm publish --access=public \
-    --registry=https://wombat-dressing-room.appspot.com
+npm publish


### PR DESCRIPTION
Update nvm and the NodeJS version it pulls in.

See [the bug](http://b/292235113) for more details. The upgraded NodeJS uses a newer NPM that doesn't complain about when being run as root.

I tested it out by in a local kokoro container and `--dry-run` flag–the tarball builds correctly:

```
npm notice                                                                                                                                   
npm notice package: pprof@3.3.0                                                                                                              
npm notice === Tarball Contents ===                                                                                                          
npm notice 11.4kB  LICENSE                                                                                                                   
npm notice 4.0kB   README.md                                                                                                                 
npm notice 718B    binding.gyp                                                                                                               
npm notice 15.2kB  bindings/profiler.cc                                                                                                      
npm notice 907B    out/src/heap-profiler-bindings.d.ts                                                                                       
npm notice 1.6kB   out/src/heap-profiler-bindings.js                                                                                         
npm notice 708B    out/src/heap-profiler-bindings.js.map                                                                                     
npm notice 1.6kB   out/src/heap-profiler.d.ts                                                                                                
npm notice 3.4kB   out/src/heap-profiler.js                                                                                                  
npm notice 1.5kB   out/src/heap-profiler.js.map                                                                                              
npm notice 602B    out/src/index.d.ts                                            
npm notice 2.2kB   out/src/index.js                                              
npm notice 899B    out/src/index.js.map                                                                                                      
npm notice 867B    out/src/profile-encoder.d.ts                                  
npm notice 2.1kB   out/src/profile-encoder.js                                                                                                
npm notice 609B    out/src/profile-encoder.js.map                                
npm notice 1.8kB   out/src/profile-serializer.d.ts                                                                                           
npm notice 9.2kB   out/src/profile-serializer.js                                                                                             
npm notice 6.6kB   out/src/profile-serializer.js.map                                                                                         
npm notice 4.0kB   out/src/sourcemapper/sourcemapper.d.ts                                                                                    
npm notice 9.7kB   out/src/sourcemapper/sourcemapper.js                                                                                      
npm notice 3.9kB   out/src/sourcemapper/sourcemapper.js.map                      
npm notice 303B    out/src/time-profiler-bindings.d.ts                                                                                       
npm notice 1.6kB   out/src/time-profiler-bindings.js                                                                                         
npm notice 776B    out/src/time-profiler-bindings.js.map                                                                                     
npm notice 1.6kB   out/src/time-profiler.d.ts                                                                                                
npm notice 3.3kB   out/src/time-profiler.js                                                                                                  
npm notice 1.2kB   out/src/time-profiler.js.map                                                                                              
npm notice 1.3kB   out/src/v8-types.d.ts                                                                                                     
npm notice 731B    out/src/v8-types.js                                                                                                       
npm notice 137B    out/src/v8-types.js.map                                                                                                   
npm notice 1.0kB   out/third_party/cloud-debug-nodejs/src/agent/io/scanner.d.ts                                                              
npm notice 8.3kB   out/third_party/cloud-debug-nodejs/src/agent/io/scanner.js                                                                
npm notice 4.5kB   out/third_party/cloud-debug-nodejs/src/agent/io/scanner.js.map                                                            
npm notice 2.7kB   package.json                                                                                                              
npm notice 40.3kB  proto/profile.d.ts                                                                                                        
npm notice 169.9kB proto/profile.js                                                                                                          
npm notice 121B    proto/README.md                                                                                                           
npm notice === Tarball Details === 
npm notice name:          pprof                                                                                                              
npm notice version:       3.3.0                                                                                                              
npm notice filename:      pprof-3.3.0.tgz                                                                                                    
npm notice package size:  45.7 kB                                                                                                            
npm notice unpacked size: 321.2 kB                                                                                                           
npm notice shasum:        f27f2f45fc7bacca3958ae31a960b21c1310c3a9                                                                           
npm notice integrity:     sha512-w32hA4nFPxwrc[...]hw7AGZS1VOx7g==                                                                           
npm notice total files:   38                                      
npm notice                                                                                                                                   
npm WARN This command requires you to be logged in to https://wombat-dressing-room.appspot.com (dry-run)                                     
npm notice Publishing to https://wombat-dressing-room.appspot.com with tag latest and default access (dry-run
```