### PR TITLE
chore: update supported node versions to 14, 16, 18, and 20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ 14, 16, 18, 19 ]
+        node: [14, 16, 18, 20]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Prerequisites
 1. Your application will need to be using Node.js 14 or greater. This package is tested against
-[current versions of Node.js][node-versions]: 14, 16, 18, and 19.
+[current versions of Node.js][node-versions]: 14, 16, 18, and 20.
 
 2. The `pprof` module has a native component that is used to collect profiles 
 with v8's CPU and Heap profilers. You may need to install additional

--- a/system-test/system_test.sh
+++ b/system-test/system_test.sh
@@ -14,7 +14,7 @@ cd $(dirname $0)
 # official releases. https://nodejs.org/en/about/releases/
 if [[ -z "$BINARY_HOST" ]]; then
   ADDITIONAL_PACKAGES="python3 g++ make"
-  NODE_VERSIONS=(14 16 18 19)
+  NODE_VERSIONS=(14 16 18 20)
 else
   # Tested versions for pre-built binaries are limited based on
   # what node-pre-gyp can specify as its target version.


### PR DESCRIPTION
Expand test support for node versions up to 20. Drop support for other non-LTS versions (odd numbered). Node 21 is not passing tests right now https://github.com/google/pprof-nodejs/issues/283, so I will hold off on that for now.