### PR TITLE
chore: fix CI to use newer npm on node 14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: node --version
+      # Upgrade npm to newest supported version so it understands lockfile v3
+      - run: npm install -g npm@9.9.3
+        if: matrix.node == 14
       - run: npm install
       - run: npm test
       - name: coverage
@@ -30,5 +33,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 14
+      # Upgrade npm to newest supported version so it understands lockfile v3
+      - run: npm install -g npm@9.9.3
       - run: npm install
       - run: npm run lint


### PR DESCRIPTION
The npm version coming with Node 14 in Github Actions is v6 which does not support lockfile v3 checked into this repo:

```
npm WARN read-shrinkwrap This version of npm is compatible with lockfileVersion@1, but package-lock.json was generated for lockfileVersion@3. I'll try to do my best with it!
```

which results in non-hermetic build (see https://github.com/google/pprof-nodejs/pull/297). This PR upgrades npm to the newest version supported in Node 14, which understands the lockfile to pull in exact dependencies.