### PR TITLE
chore: upgrade nodejs/nan to 2.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "bindings": "^1.2.1",
         "delay": "^5.0.0",
         "findit2": "^2.2.3",
-        "nan": "^2.17.0",
+        "nan": "^2.22.0",
         "p-limit": "^3.0.0",
         "protobufjs": "~7.2.4",
         "source-map": "~0.8.0-beta.0",
@@ -4693,9 +4693,10 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bindings": "^1.2.1",
     "delay": "^5.0.0",
     "findit2": "^2.2.3",
-    "nan": "^2.17.0",
+    "nan": "^2.22.0",
     "p-limit": "^3.0.0",
     "protobufjs": "~7.2.4",
     "source-map": "~0.8.0-beta.0",


### PR DESCRIPTION
This PR upgrades `nan` to version 2.22, ensuring compatibility on NodeJS 21 and greater.

The main culprit when building `pprof` was `SetAccessor` being renamed, see here: https://github.com/nodejs/nan/commit/6bd62c9a0004339d5d1e18a945c84929d0f6b808

`npm run test`: ✅ 
`system-test/system_test.sh`: ✅ 